### PR TITLE
pending reconciles

### DIFF
--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -76,7 +76,7 @@ func main() {
 		fmt.Println(e.Timestamp, e.ControllerID, util.Shorter(e.ReconcileID), e.OpType, e.CausalKey().Short())
 	}
 
-	km := tracecheck.NewGlobalKnowledge(store)
+	km := tracecheck.NewEventKnowledge(store)
 	km.Load(events)
 	rPodKnowledge := km.Kinds["RPod"]
 	rPodKnowledge.Summarize()

--- a/pkg/replay/client.go
+++ b/pkg/replay/client.go
@@ -46,7 +46,7 @@ func NewClient(reconcilerID string, scheme *runtime.Scheme, frameData frameConta
 	}
 }
 
-func (c *Client) InsertFrame(id string, data FrameData) {
+func (c *Client) InsertFrame(id string, data CacheFrame) {
 	if _, ok := c.framesByID[id]; ok {
 		panic(fmt.Sprintf("frame %s already exists", id))
 	}

--- a/pkg/replay/frame.go
+++ b/pkg/replay/frame.go
@@ -46,12 +46,12 @@ func FrameIDFromContext(ctx context.Context) string {
 	return id
 }
 
-// FrameData is a map of kind -> namespace/name -> object
+// CacheFrame is a map of kind -> namespace/name -> object
 // and it is keyed by namespace/name cause that is the access pattern that controller code uses.
-type FrameData map[string]map[types.NamespacedName]*unstructured.Unstructured
+type CacheFrame map[string]map[types.NamespacedName]*unstructured.Unstructured
 
-func (c FrameData) Copy() FrameData {
-	newFrame := make(FrameData)
+func (c CacheFrame) Copy() CacheFrame {
+	newFrame := make(CacheFrame)
 	for kind, objs := range c {
 		newFrame[kind] = make(map[types.NamespacedName]*unstructured.Unstructured)
 		for nn, obj := range objs {
@@ -61,7 +61,7 @@ func (c FrameData) Copy() FrameData {
 	return newFrame
 }
 
-func (c FrameData) Dump() {
+func (c CacheFrame) Dump() {
 	for kind, objs := range c {
 		for nn := range objs {
 			fmt.Printf("\t%s/%s/%s\n", kind, nn.Namespace, nn.Name)
@@ -69,7 +69,8 @@ func (c FrameData) Dump() {
 	}
 }
 
-type frameContainer map[string]FrameData
+// frameContainer maps reconcileID -> CacheFrame
+type frameContainer map[string]CacheFrame
 
 type FrameManager struct {
 	Frames frameContainer
@@ -84,9 +85,9 @@ func NewFrameManager(initialFrames frameContainer) *FrameManager {
 	}
 }
 
-func (fm *FrameManager) InsertFrame(id string, data FrameData) {
-	if _, ok := fm.Frames[id]; ok {
-		panic(fmt.Sprintf("frame %s already exists", id))
+func (fm *FrameManager) InsertFrame(reconcileID string, data CacheFrame) {
+	if _, ok := fm.Frames[reconcileID]; ok {
+		panic(fmt.Sprintf("frame %s already exists", reconcileID))
 	}
-	fm.Frames[id] = data
+	fm.Frames[reconcileID] = data
 }

--- a/pkg/replay/player.go
+++ b/pkg/replay/player.go
@@ -26,7 +26,7 @@ type Harness struct {
 	predicates []*executionPredicate
 }
 
-func newHarness(reconcilerID string, frames []Frame, frameData map[string]FrameData, effects map[string]DataEffect) *Harness {
+func newHarness(reconcilerID string, frames []Frame, frameData map[string]CacheFrame, effects map[string]DataEffect) *Harness {
 	replayEffects := make(map[string]DataEffect)
 	return &Harness{
 		frames:             frames,
@@ -39,7 +39,7 @@ func newHarness(reconcilerID string, frames []Frame, frameData map[string]FrameD
 }
 
 func (p *Harness) FrameData() frameContainer {
-	copy := make(map[string]FrameData)
+	copy := make(map[string]CacheFrame)
 	maps.Copy(copy, p.frameDataByFrameID)
 	return copy
 }

--- a/pkg/snapshot/store.go
+++ b/pkg/snapshot/store.go
@@ -89,7 +89,6 @@ func (s *Store) StoreObject(obj *unstructured.Unstructured) error {
 
 func (s *Store) PublishWithStrategy(obj *unstructured.Unstructured, strategy HashStrategy) VersionHash {
 	// Calculate hash
-	fmt.Println("publishing object to snapStore", &s)
 	hash, err := s.hashGenerators[strategy].Hash(obj)
 	if err != nil {
 		panic(fmt.Sprintf("error hashing object: %v", err))

--- a/pkg/snapshot/store.go
+++ b/pkg/snapshot/store.go
@@ -48,6 +48,10 @@ func NewStore() *Store {
 	return store
 }
 
+func (s *Store) GetVersionMap(strategy HashStrategy) map[VersionHash]*unstructured.Unstructured {
+	return s.indices[strategy]
+}
+
 func (s *Store) RegisterHashGenerator(strategy HashStrategy, generator Hasher) {
 	s.hashGenerators[strategy] = generator
 }

--- a/pkg/snapshot/store_test.go
+++ b/pkg/snapshot/store_test.go
@@ -42,7 +42,7 @@ func createTestObject(namespace, name string, labels map[string]string) *unstruc
 }
 
 func TestNewObjectStore(t *testing.T) {
-	store := NewObjectStore()
+	store := NewStore()
 
 	assert.NotNil(t, store.indices)
 	assert.NotNil(t, store.objectHashes)
@@ -54,7 +54,7 @@ func TestNewObjectStore(t *testing.T) {
 }
 
 func TestRegisterHashGenerator(t *testing.T) {
-	store := NewObjectStore()
+	store := NewStore()
 
 	customStrategy := HashStrategy("custom")
 	customHasher := &MockDefaultHasher{}
@@ -65,7 +65,7 @@ func TestRegisterHashGenerator(t *testing.T) {
 }
 
 func TestStoreObject(t *testing.T) {
-	store := NewObjectStore()
+	store := NewStore()
 
 	// Register our mock hashers
 	store.RegisterHashGenerator(DefaultHash, &MockDefaultHasher{})
@@ -100,7 +100,7 @@ func TestStoreObject(t *testing.T) {
 }
 
 func TestStoreObjectError(t *testing.T) {
-	store := NewObjectStore()
+	store := NewStore()
 
 	// Register a hasher that returns an error
 	store.RegisterHashGenerator(DefaultHash, &ErrorHasher{})
@@ -115,7 +115,7 @@ func TestStoreObjectError(t *testing.T) {
 }
 
 func TestGetByHash(t *testing.T) {
-	store := NewObjectStore()
+	store := NewStore()
 
 	// Register our mock hashers
 	store.RegisterHashGenerator(DefaultHash, &MockDefaultHasher{})
@@ -152,7 +152,7 @@ func TestGetByHash(t *testing.T) {
 }
 
 func TestGetByHashWithMultipleObjects(t *testing.T) {
-	store := NewObjectStore()
+	store := NewStore()
 
 	// Register mock hashers where the anonymized hasher gives same hash for different objects
 	store.RegisterHashGenerator(DefaultHash, &MockDefaultHasher{})
@@ -188,7 +188,7 @@ func TestGetByHashWithMultipleObjects(t *testing.T) {
 }
 
 func TestConvertHash(t *testing.T) {
-	store := NewObjectStore()
+	store := NewStore()
 
 	// Register our mock hashers
 	store.RegisterHashGenerator(DefaultHash, &MockDefaultHasher{})
@@ -219,7 +219,7 @@ func TestConvertHash(t *testing.T) {
 }
 
 func TestUpdateObject(t *testing.T) {
-	store := NewObjectStore()
+	store := NewStore()
 
 	// Register our mock hashers
 	store.RegisterHashGenerator(DefaultHash, &MockDefaultHasher{})
@@ -253,7 +253,7 @@ func TestConcurrentHashClash(t *testing.T) {
 	// This test simulates the scenario where two different objects get the same hash
 	// in one strategy but different hashes in another strategy
 
-	store := NewObjectStore()
+	store := NewStore()
 
 	// Define a custom hasher that gives the same hash for objects with names that start with "clash-"
 	clashHasher := &MockAnonymizedHasher{}

--- a/pkg/tracecheck/converter.go
+++ b/pkg/tracecheck/converter.go
@@ -8,6 +8,7 @@ import (
 	"github.com/tgoodwin/sleeve/pkg/event"
 	"github.com/tgoodwin/sleeve/pkg/snapshot"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 // TODO this code can likely be replaced by the staleness eventsourcing package
@@ -110,7 +111,12 @@ func (c *converterImpl) getStart() StateNode {
 	firstRecord := c.orderedJoinRecords[0]
 	firstOV := c.reconcileIDToReads[firstRecord.event.ReconcileID]
 	return StateNode{
-		objects:           firstOV,
-		PendingReconciles: []string{firstRecord.event.ControllerID},
+		objects: firstOV,
+		PendingReconciles: []PendingReconcile{
+			{
+				ReconcilerID: firstRecord.event.ControllerID,
+				Request:      reconcile.Request{},
+			},
+		},
 	}
 }

--- a/pkg/tracecheck/explore.go
+++ b/pkg/tracecheck/explore.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/samber/lo"
 	"github.com/tgoodwin/sleeve/pkg/replay"
-	"github.com/tgoodwin/sleeve/pkg/snapshot"
 	"github.com/tgoodwin/sleeve/pkg/util"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -34,9 +33,10 @@ type Explorer struct {
 
 	knowledgeManager *EventKnowledge
 
+	triggerManager *TriggerManager
+
 	// config
-	maxDepth     int
-	hashStrategy snapshot.HashStrategy // how to serialize states for equality comparison
+	maxDepth int
 }
 
 type ConvergedState struct {
@@ -299,6 +299,12 @@ func (e *Explorer) getTriggeredReconcilers(changes ObjectVersions) []PendingReco
 			Request:      reconcile.Request{},
 		}
 	})
+	alternative := e.triggerManager.MustGetTriggered(changes)
+	if len(alternative) != len(out) {
+		fmt.Println("triggered reconcilers mismatch")
+		fmt.Println("out", out)
+		fmt.Println("alternative", alternative)
+	}
 	return out
 }
 

--- a/pkg/tracecheck/explore.go
+++ b/pkg/tracecheck/explore.go
@@ -32,7 +32,7 @@ type Explorer struct {
 	// maps Kinds to a list of reconcilerIDs that depend on them
 	dependencies ResourceDeps
 
-	knowledgeManager *GlobalKnowledge
+	knowledgeManager *EventKnowledge
 
 	// config
 	maxDepth     int

--- a/pkg/tracecheck/explore_test.go
+++ b/pkg/tracecheck/explore_test.go
@@ -3,7 +3,6 @@ package tracecheck
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/tgoodwin/sleeve/pkg/snapshot"
 )
 
@@ -30,7 +29,10 @@ func Test_serializeState(t *testing.T) {
 							ObjectID: "object2",
 						}: snapshot.NewDefaultHash("hash2"),
 					},
-					PendingReconciles: []string{"controller1", "controller2"},
+					PendingReconciles: []PendingReconcile{
+						{ReconcilerID: "controller1"},
+						{ReconcilerID: "controller2"},
+					},
 					// Initialize with some test data
 				},
 			},
@@ -48,33 +50,33 @@ func Test_serializeState(t *testing.T) {
 	}
 }
 
-func Test_getNewPendingReconciles(t *testing.T) {
-	tests := []struct {
-		name     string
-		curr     []string
-		new      []string
-		expected []string
-	}{
-		{
-			name:     "identical lists",
-			curr:     []string{"controllerC", "controllerB"},
-			new:      []string{"controllerB", "controllerC"},
-			expected: []string{"controllerC", "controllerB"},
-		},
-		{
-			name:     "one new controller",
-			curr:     []string{"controllerC", "controllerB"},
-			new:      []string{"controllerB", "controllerC", "controllerA"},
-			expected: []string{"controllerC", "controllerB", "controllerA"},
-		},
-	}
+// func Test_getNewPendingReconciles(t *testing.T) {
+// 	tests := []struct {
+// 		name     string
+// 		curr     []string
+// 		new      []string
+// 		expected []string
+// 	}{
+// 		{
+// 			name:     "identical lists",
+// 			curr:     []string{"controllerC", "controllerB"},
+// 			new:      []string{"controllerB", "controllerC"},
+// 			expected: []string{"controllerC", "controllerB"},
+// 		},
+// 		{
+// 			name:     "one new controller",
+// 			curr:     []string{"controllerC", "controllerB"},
+// 			new:      []string{"controllerB", "controllerC", "controllerA"},
+// 			expected: []string{"controllerC", "controllerB", "controllerA"},
+// 		},
+// 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			actual := getNewPendingReconciles(tt.curr, tt.new)
-			if !assert.Equal(t, actual, tt.expected) {
-				t.Errorf("getNewPendingReconciles() = %v, want %v", actual, tt.expected)
-			}
-		})
-	}
-}
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			actual := getNewPendingReconciles(tt.curr, tt.new)
+// 			if !assert.Equal(t, actual, tt.expected) {
+// 				t.Errorf("getNewPendingReconciles() = %v, want %v", actual, tt.expected)
+// 			}
+// 		})
+// 	}
+// }

--- a/pkg/tracecheck/explore_test.go
+++ b/pkg/tracecheck/explore_test.go
@@ -3,6 +3,7 @@ package tracecheck
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/tgoodwin/sleeve/pkg/snapshot"
 )
 
@@ -50,33 +51,53 @@ func Test_serializeState(t *testing.T) {
 	}
 }
 
-// func Test_getNewPendingReconciles(t *testing.T) {
-// 	tests := []struct {
-// 		name     string
-// 		curr     []string
-// 		new      []string
-// 		expected []string
-// 	}{
-// 		{
-// 			name:     "identical lists",
-// 			curr:     []string{"controllerC", "controllerB"},
-// 			new:      []string{"controllerB", "controllerC"},
-// 			expected: []string{"controllerC", "controllerB"},
-// 		},
-// 		{
-// 			name:     "one new controller",
-// 			curr:     []string{"controllerC", "controllerB"},
-// 			new:      []string{"controllerB", "controllerC", "controllerA"},
-// 			expected: []string{"controllerC", "controllerB", "controllerA"},
-// 		},
-// 	}
+func Test_getNewPendingReconciles(t *testing.T) {
+	tests := []struct {
+		name     string
+		curr     []PendingReconcile
+		new      []PendingReconcile
+		expected []PendingReconcile
+	}{
+		{
+			name: "identical lists",
+			curr: []PendingReconcile{
+				{ReconcilerID: "controllerC"},
+				{ReconcilerID: "controllerB"},
+			},
+			new: []PendingReconcile{
+				{ReconcilerID: "controllerB"},
+				{ReconcilerID: "controllerC"},
+			},
+			expected: []PendingReconcile{
+				{ReconcilerID: "controllerC"},
+				{ReconcilerID: "controllerB"},
+			},
+		},
+		{
+			name: "one new controller",
+			curr: []PendingReconcile{
+				{ReconcilerID: "controllerC"},
+				{ReconcilerID: "controllerB"},
+			},
+			new: []PendingReconcile{
+				{ReconcilerID: "controllerB"},
+				{ReconcilerID: "controllerC"},
+				{ReconcilerID: "controllerA"},
+			},
+			expected: []PendingReconcile{
+				{ReconcilerID: "controllerC"},
+				{ReconcilerID: "controllerB"},
+				{ReconcilerID: "controllerA"},
+			},
+		},
+	}
 
-// 	for _, tt := range tests {
-// 		t.Run(tt.name, func(t *testing.T) {
-// 			actual := getNewPendingReconciles(tt.curr, tt.new)
-// 			if !assert.Equal(t, actual, tt.expected) {
-// 				t.Errorf("getNewPendingReconciles() = %v, want %v", actual, tt.expected)
-// 			}
-// 		})
-// 	}
-// }
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := getNewPendingReconciles(tt.curr, tt.new)
+			if !assert.Equal(t, actual, tt.expected) {
+				t.Errorf("getNewPendingReconciles() = %v, want %v", actual, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/tracecheck/manager.go
+++ b/pkg/tracecheck/manager.go
@@ -50,7 +50,6 @@ func newEffect(kind, uid string, version snapshot.VersionHash, op event.Operatio
 type manager struct {
 	*versionStore // maps hashes to full object values
 	// (Kind+objectID) -> []versionHash
-	*snapshot.LifecycleContainer // for each Object IdentityKey, store all value hashes and the reconciles that produced them
 
 	// need to add frame data to the manager as well for reconciler reads
 	*converterImpl
@@ -95,12 +94,6 @@ func (m *manager) RecordEffect(ctx context.Context, obj client.Object, opType ev
 	}
 	// publish the object versionHash
 	versionHash := m.Publish(u)
-	ikey := snapshot.IdentityKey{
-		Kind:     kind,
-		ObjectID: objectID,
-	}
-	// add the version to the object's lifecycle
-	m.InsertSynthesizedVersion(ikey, versionHash, frameID)
 
 	// now manifest an event and record it as an effect
 	reffects, ok := m.effects[frameID]

--- a/pkg/tracecheck/manager.go
+++ b/pkg/tracecheck/manager.go
@@ -62,7 +62,7 @@ type manager struct {
 }
 
 func (m *manager) Summary() {
-	store := m.versionStore.store
+	store := m.versionStore.snapStore.GetVersionMap(snapshot.AnonymizedHash)
 	for k, v := range store {
 		fmt.Printf("Key: %s, Value: %s\n", k, v)
 	}

--- a/pkg/tracecheck/reconciler.go
+++ b/pkg/tracecheck/reconciler.go
@@ -20,7 +20,7 @@ type effectReader interface {
 }
 
 type frameInserter interface {
-	InsertFrame(id string, data replay.FrameData)
+	InsertFrame(id string, data replay.CacheFrame)
 }
 
 type reconcileImpl struct {
@@ -125,8 +125,8 @@ func (r *reconcileImpl) inferReconcileRequest(readset ObjectVersions) (reconcile
 	return reconcile.Request{}, errors.New(fmt.Sprintf("no object of kind %s in readset", r.For))
 }
 
-func (r *reconcileImpl) toFrameData(ov ObjectVersions) replay.FrameData {
-	out := make(replay.FrameData)
+func (r *reconcileImpl) toFrameData(ov ObjectVersions) replay.CacheFrame {
+	out := make(replay.CacheFrame)
 
 	for key, hash := range ov {
 		kind := key.Kind

--- a/pkg/tracecheck/reconciler.go
+++ b/pkg/tracecheck/reconciler.go
@@ -39,7 +39,7 @@ type reconcileImpl struct {
 	frameInserter
 }
 
-func (r *reconcileImpl) doReconcile(ctx context.Context, currState ObjectVersions) (*ReconcileResult, error) {
+func (r *reconcileImpl) doReconcile(ctx context.Context, currState ObjectVersions, req reconcile.Request) (*ReconcileResult, error) {
 	// create a new cache frame from the current state of the world of objects.
 	// the Reconciler's readset will be a subset of this frame
 	frameID := util.UUID()

--- a/pkg/tracecheck/result_writer.go
+++ b/pkg/tracecheck/result_writer.go
@@ -55,6 +55,15 @@ func (tc *TraceChecker) writeStateSummary(state ConvergedState, outPath string) 
 	// Write state summary to the file
 	file.WriteString("# Converged State Summary:\n")
 	file.WriteString(fmt.Sprintf("Divergence point: %s\n", state.State.DivergencePoint))
+	file.WriteString("state keys:\n")
+	keys := lo.Keys(state.State.Objects())
+	sort.Slice(keys, func(i, j int) bool {
+		return keys[i].ObjectID < keys[j].ObjectID
+	})
+	for _, k := range keys {
+		file.WriteString(fmt.Sprintf("\t%s\n", k))
+	}
+	file.WriteString("\n")
 	file.WriteString("## Converged Objects:\n")
 	objectKeys := lo.Keys(state.State.Objects())
 	sort.Slice(objectKeys, func(i, j int) bool {

--- a/pkg/tracecheck/staleness.go
+++ b/pkg/tracecheck/staleness.go
@@ -119,14 +119,14 @@ type VersionResolver interface {
 }
 
 type KnowledgeManager struct {
-	snapStore *snapshot.ObjectStore
+	snapStore *snapshot.Store
 	*GlobalKnowledge
 	eventKeyToVersion map[event.CausalKey]snapshot.VersionHash
 }
 
 func NewKnowledgeManager() *KnowledgeManager {
 	return &KnowledgeManager{
-		snapStore:         snapshot.NewObjectStore(),
+		snapStore:         snapshot.NewStore(),
 		GlobalKnowledge:   NewGlobalKnowledge(nil),
 		eventKeyToVersion: make(map[event.CausalKey]snapshot.VersionHash),
 	}
@@ -303,7 +303,7 @@ func (e ErrInsufficientEvents) Error() string {
 		e.Kind, e.Steps, e.RequestedSeq, e.CurrentSeq)
 }
 
-func (g *GlobalKnowledge) AdjustKnowledgeForKind(snapshot *StateSnapshot, kind string, steps int64) (*StateSnapshot, error) {
+func (g *GlobalKnowledge) AdjustKnowledgeForResourceType(snapshot *StateSnapshot, kind string, steps int64) (*StateSnapshot, error) {
 	kindKnowledge, exists := g.Kinds[kind]
 	if !exists {
 		return nil, fmt.Errorf("unknown kind: %s", kind)

--- a/pkg/tracecheck/staleness_test.go
+++ b/pkg/tracecheck/staleness_test.go
@@ -518,7 +518,7 @@ func TestGlobalKnowledge_replayEventsToState(t *testing.T) {
 		if countPods(state) != 1 {
 			t.Errorf("Expected 1 pods in state, got %d", len(state.Objects()))
 		}
-		rewind, err := g.AdjustKnowledgeForKind(state, "Pod", -1)
+		rewind, err := g.AdjustKnowledgeForResourceType(state, "Pod", -1)
 		if err != nil {
 			t.Fatalf("AdjustKnowledgeForKind failed: %v", err)
 		}
@@ -526,7 +526,7 @@ func TestGlobalKnowledge_replayEventsToState(t *testing.T) {
 			t.Errorf("Expected 2 pods in state, got %d", len(rewind.Objects()))
 		}
 
-		ff, err := g.AdjustKnowledgeForKind(state, "Pod", 1)
+		ff, err := g.AdjustKnowledgeForResourceType(state, "Pod", 1)
 		if err != nil {
 			t.Fatalf("AdjustKnowledgeForKind failed: %v", err)
 		}

--- a/pkg/tracecheck/staleness_test.go
+++ b/pkg/tracecheck/staleness_test.go
@@ -148,7 +148,7 @@ func TestGlobalKnowledgeLoad(t *testing.T) {
 
 		// Create a mock version resolver for testing
 		mockResolver := &MockVersionResolver{}
-		g := NewGlobalKnowledge(mockResolver)
+		g := NewEventKnowledge(mockResolver)
 		err := g.Load(testEvents)
 		if err != nil {
 			t.Fatalf("Load failed: %v", err)
@@ -251,7 +251,7 @@ func TestGlobalKnowledgeLoad(t *testing.T) {
 			},
 		}
 
-		g := NewGlobalKnowledge(&MockVersionResolver{})
+		g := NewEventKnowledge(&MockVersionResolver{})
 		err := g.Load(events)
 		if err != nil {
 			t.Fatalf("Load failed: %v", err)
@@ -442,7 +442,7 @@ func TestGlobalKnowledge_replayEventsToState(t *testing.T) {
 		},
 	}
 	t.Run("replay all events", func(t *testing.T) {
-		g := NewGlobalKnowledge(&MockVersionResolver{})
+		g := NewEventKnowledge(&MockVersionResolver{})
 		err := g.Load(events)
 		if err != nil {
 			t.Fatalf("Load failed: %v", err)
@@ -477,7 +477,7 @@ func TestGlobalKnowledge_replayEventsToState(t *testing.T) {
 		}
 	})
 	t.Run("reply half the events", func(t *testing.T) {
-		g := NewGlobalKnowledge(&MockVersionResolver{})
+		g := NewEventKnowledge(&MockVersionResolver{})
 		err := g.Load(events)
 		if err != nil {
 			t.Fatalf("Load failed: %v", err)
@@ -508,7 +508,7 @@ func TestGlobalKnowledge_replayEventsToState(t *testing.T) {
 			}
 			return count
 		}
-		g := NewGlobalKnowledge(&MockVersionResolver{})
+		g := NewEventKnowledge(&MockVersionResolver{})
 		err := g.Load(events)
 		if err != nil {
 			t.Fatalf("Load failed: %v", err)

--- a/pkg/tracecheck/state.go
+++ b/pkg/tracecheck/state.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/samber/lo"
 	"github.com/tgoodwin/sleeve/pkg/snapshot"
+	"github.com/tgoodwin/sleeve/pkg/util"
 )
 
 type HashInfo struct {
@@ -66,7 +67,7 @@ type ExecutionHistory []*ReconcileResult
 
 func (eh ExecutionHistory) SummarizeToFile(file *os.File) error {
 	for _, r := range eh {
-		_, err := fmt.Fprintf(file, "\t%s:%s - #changes=%d\n", r.ControllerID, r.FrameID, len(r.Changes))
+		_, err := fmt.Fprintf(file, "\t%s:%s (%s) - #changes=%d\n", r.ControllerID, util.Shorter(r.FrameID), r.FrameType, len(r.Changes))
 		if err != nil {
 			return err
 		}
@@ -124,7 +125,7 @@ type StateNode struct {
 	objects ObservableState
 	// PendingReconciles is a list of controller IDs that are pending reconciliation.
 	// In our "game tree", they represent branches that we can explore.
-	PendingReconciles []string
+	PendingReconciles []PendingReconcile
 
 	parent *StateNode
 	action *ReconcileResult // the action that led to this state

--- a/pkg/tracecheck/store.go
+++ b/pkg/tracecheck/store.go
@@ -3,18 +3,12 @@ package tracecheck
 import (
 	"sync"
 
-	"github.com/tgoodwin/sleeve/pkg/event"
 	"github.com/tgoodwin/sleeve/pkg/snapshot"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-type Store map[snapshot.VersionHash]*unstructured.Unstructured
-
 type versionStore struct {
-	snapStore          *snapshot.Store
-	store              Store
-	keyToObj           map[event.CausalKey]*unstructured.Unstructured
-	causalKeyToVersion map[event.CausalKey]snapshot.VersionHash
+	snapStore *snapshot.Store
 
 	// TODO perhaps multiple hash strategies?
 	hasher snapshot.Hasher
@@ -26,10 +20,8 @@ var _ VersionManager = (*versionStore)(nil)
 
 func newVersionStore() *versionStore {
 	return &versionStore{
-		snapStore:          snapshot.NewStore(),
-		store:              make(Store),
-		causalKeyToVersion: make(map[event.CausalKey]snapshot.VersionHash),
-		keyToObj:           make(map[event.CausalKey]*unstructured.Unstructured),
+		snapStore: snapshot.NewStore(),
+		// store:              make(Store),
 		hasher: snapshot.NewAnonymizingHasher(
 			snapshot.DefaultLabelReplacements,
 		),

--- a/pkg/tracecheck/store.go
+++ b/pkg/tracecheck/store.go
@@ -11,7 +11,7 @@ import (
 type Store map[snapshot.VersionHash]*unstructured.Unstructured
 
 type versionStore struct {
-	snapStore          *snapshot.ObjectStore
+	snapStore          *snapshot.Store
 	store              Store
 	keyToObj           map[event.CausalKey]*unstructured.Unstructured
 	causalKeyToVersion map[event.CausalKey]snapshot.VersionHash
@@ -26,7 +26,7 @@ var _ VersionManager = (*versionStore)(nil)
 
 func newVersionStore() *versionStore {
 	return &versionStore{
-		snapStore:          snapshot.NewObjectStore(),
+		snapStore:          snapshot.NewStore(),
 		store:              make(Store),
 		causalKeyToVersion: make(map[event.CausalKey]snapshot.VersionHash),
 		keyToObj:           make(map[event.CausalKey]*unstructured.Unstructured),

--- a/pkg/tracecheck/tracecheck.go
+++ b/pkg/tracecheck/tracecheck.go
@@ -276,10 +276,10 @@ func (tc *TraceChecker) NewExplorer(maxDepth int) *Explorer {
 
 	// if constructing an explorer from trace data, load a knowledge manager.
 	// otherwise we need to skip this step. TODO refactor
-	var knowledgeManager *GlobalKnowledge
+	var knowledgeManager *EventKnowledge
 	// TODO should be able to just check if the builder is nil or not
 	if tc.mode == "traced" {
-		knowledgeManager = NewGlobalKnowledge(tc.builder.Store())
+		knowledgeManager = NewEventKnowledge(tc.builder.Store())
 		knowledgeManager.Load(tc.builder.Events())
 	}
 

--- a/pkg/tracecheck/tracecheck.go
+++ b/pkg/tracecheck/tracecheck.go
@@ -3,6 +3,7 @@ package tracecheck
 import (
 	"fmt"
 
+	"github.com/samber/lo"
 	sleeveclient "github.com/tgoodwin/sleeve/pkg/client"
 	"github.com/tgoodwin/sleeve/pkg/event"
 	"github.com/tgoodwin/sleeve/pkg/replay"
@@ -78,7 +79,7 @@ func FromBuilder(b *replay.Builder) *TraceChecker {
 	lc := snapshot.NewLifecycleContainer()
 
 	//snapshot store
-	snapshotStore := snapshot.NewObjectStore()
+	snapshotStore := snapshot.NewStore()
 
 	store := b.Store()
 	// eventsByReconcile := lo.GroupBy(b.Events(), func(e event.Event) string {
@@ -164,9 +165,16 @@ func (tc *TraceChecker) GetStartStateFromObject(obj client.Object, dependentCont
 		ReconcilerIDs: util.NewSet(dependentControllers...),
 	}
 
+	dependent := lo.Map(dependentControllers, func(s string, _ int) PendingReconcile {
+		return PendingReconcile{
+			ReconcilerID: s,
+			Request:      reconcile.Request{},
+		}
+	})
+
 	return StateNode{
 		objects:           ObjectVersions{ikey: vHash},
-		PendingReconciles: dependentControllers,
+		PendingReconciles: dependent,
 	}
 }
 

--- a/pkg/tracecheck/tracecheck.go
+++ b/pkg/tracecheck/tracecheck.go
@@ -288,6 +288,12 @@ func (tc *TraceChecker) NewExplorer(maxDepth int) *Explorer {
 		dependencies: tc.ResourceDeps,
 		maxDepth:     maxDepth,
 
+		triggerManager: NewTriggerManager(
+			tc.ResourceDeps,
+			tc.reconcilerToKind,
+			tc.manager.snapStore,
+		),
+
 		knowledgeManager: knowledgeManager,
 	}
 }

--- a/pkg/tracecheck/trigger.go
+++ b/pkg/tracecheck/trigger.go
@@ -15,9 +15,9 @@ import (
 // ResourceDeps is a map of resource kinds to the reconcilers that depend on them
 type ResourceDeps map[string]util.Set[string]
 
-// OwnerByKind tracks the owner of a resource by kind, where owner is the reconciler that
+// PrimariesByKind tracks the owner of a resource by kind, where owner is the reconciler that
 // has ControllerManagedBy.For called with the kind of the resource
-type OwnerByKind map[string]string
+type PrimariesByKind map[string]util.Set[string]
 
 type PendingReconcile struct {
 	ReconcilerID string
@@ -28,17 +28,27 @@ type hashResolver interface {
 	GetByHash(hash snapshot.VersionHash, strategy snapshot.HashStrategy) (*unstructured.Unstructured, bool)
 }
 
+// TriggerManager handles the dependency graph between resources and reconcilers
+// and models the event-driven mechanism that triggers reconcilers upon changes to resources
 type TriggerManager struct {
 	deps     ResourceDeps
-	owners   OwnerByKind
+	owners   PrimariesByKind
 	resolver hashResolver
 }
 
 // NewTriggerManager creates a new instance of TriggerManager
-func NewTriggerManager(deps ResourceDeps, owners OwnerByKind, resolver hashResolver) *TriggerManager {
+func NewTriggerManager(deps ResourceDeps, reconcilerToPrimaryKind map[string]string, resolver hashResolver) *TriggerManager {
+
+	primariesByKind := make(PrimariesByKind)
+	for reconcilerID, kind := range reconcilerToPrimaryKind {
+		if _, exists := primariesByKind[kind]; !exists {
+			primariesByKind[kind] = make(util.Set[string])
+		}
+		primariesByKind[kind].Add(reconcilerID)
+	}
 	return &TriggerManager{
 		deps:     deps,
-		owners:   owners,
+		owners:   primariesByKind,
 		resolver: resolver,
 	}
 }
@@ -61,14 +71,16 @@ func (tm *TriggerManager) getTriggered(changes ObjectVersions) ([]PendingReconci
 			Name:      objectVal.GetName(),
 		}
 
-		// Add primary reconciler if available
-		if primaryReconcilerID, exists := tm.owners[objKey.Kind]; exists {
-			reconcileKey := fmt.Sprintf("%s:%s:%s", primaryReconcilerID, nsName.Namespace, nsName.Name)
-			uniqueReconciles[reconcileKey] = PendingReconcile{
-				ReconcilerID: primaryReconcilerID,
-				Request: reconcile.Request{
-					NamespacedName: nsName,
-				},
+		// Add primary reconcilers if available
+		if primaries, exists := tm.owners[objKey.Kind]; exists {
+			for primaryReconcilerID := range primaries {
+				reconcileKey := fmt.Sprintf("%s:%s:%s", primaryReconcilerID, nsName.Namespace, nsName.Name)
+				uniqueReconciles[reconcileKey] = PendingReconcile{
+					ReconcilerID: primaryReconcilerID,
+					Request: reconcile.Request{
+						NamespacedName: nsName,
+					},
+				}
 			}
 		}
 
@@ -76,20 +88,22 @@ func (tm *TriggerManager) getTriggered(changes ObjectVersions) ([]PendingReconci
 		if objectVal.GetOwnerReferences() != nil {
 			for _, ownerRef := range objectVal.GetOwnerReferences() {
 				// Only process if we have a registered reconciler for this owner kind
-				if ownerReconcilerID, exists := tm.owners[ownerRef.Kind]; exists {
-					ownerNSName := types.NamespacedName{
-						// TODO this is an assumption that the owner is in the same namespace
-						// as the owned object
-						Namespace: objectVal.GetNamespace(),
-						Name:      ownerRef.Name,
-					}
+				if primaries, exists := tm.owners[ownerRef.Kind]; exists {
+					for ownerReconcilerID := range primaries {
+						ownerNSName := types.NamespacedName{
+							// TODO this is an assumption that the owner is in the same namespace
+							// as the owned object
+							Namespace: objectVal.GetNamespace(),
+							Name:      ownerRef.Name,
+						}
 
-					reconcileKey := fmt.Sprintf("%s:%s:%s", ownerReconcilerID, ownerNSName.Namespace, ownerNSName.Name)
-					uniqueReconciles[reconcileKey] = PendingReconcile{
-						ReconcilerID: ownerReconcilerID,
-						Request: reconcile.Request{
-							NamespacedName: ownerNSName,
-						},
+						reconcileKey := fmt.Sprintf("%s:%s:%s", ownerReconcilerID, ownerNSName.Namespace, ownerNSName.Name)
+						uniqueReconciles[reconcileKey] = PendingReconcile{
+							ReconcilerID: ownerReconcilerID,
+							Request: reconcile.Request{
+								NamespacedName: ownerNSName,
+							},
+						}
 					}
 				}
 			}
@@ -112,6 +126,12 @@ func (tm *TriggerManager) getTriggered(changes ObjectVersions) ([]PendingReconci
 		}
 		return result[i].Request.Name < result[j].Request.Name
 	})
+
+	// Debug print the pending reconciles
+	// for _, reconcile := range result {
+	// 	fmt.Printf("PendingReconcile: ReconcilerID=%s, nsName=%s/%s\n",
+	// 		reconcile.ReconcilerID, reconcile.Request.Namespace, reconcile.Request.Name)
+	// }
 
 	return result, nil
 }

--- a/pkg/tracecheck/trigger.go
+++ b/pkg/tracecheck/trigger.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/samber/lo"
 	"github.com/tgoodwin/sleeve/pkg/snapshot"
 	"github.com/tgoodwin/sleeve/pkg/util"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -123,4 +124,15 @@ func (tm *TriggerManager) MustGetTriggered(changes ObjectVersions) []PendingReco
 		panic(err.Error())
 	}
 	return result
+}
+
+func NewPendingReconciles(nsName types.NamespacedName, dependentControllers ...string) []PendingReconcile {
+	return lo.Map(dependentControllers, func(controllerID string, _ int) PendingReconcile {
+		return PendingReconcile{
+			ReconcilerID: controllerID,
+			Request: reconcile.Request{
+				NamespacedName: nsName,
+			},
+		}
+	})
 }

--- a/pkg/tracecheck/trigger.go
+++ b/pkg/tracecheck/trigger.go
@@ -70,6 +70,10 @@ func (tm *TriggerManager) getTriggered(changes ObjectVersions) ([]PendingReconci
 			Namespace: objectVal.GetNamespace(),
 			Name:      objectVal.GetName(),
 		}
+		// check to ensure the object has a namespaced name
+		if nsName.Name == "" || nsName.Namespace == "" {
+			return nil, fmt.Errorf("resolved object %s has no namespaced name", objKey)
+		}
 
 		// Add primary reconcilers if available
 		if primaries, exists := tm.owners[objKey.Kind]; exists {


### PR DESCRIPTION
Want to remove the reconcile request inferral logic and do so explicitly by
accurately modeling the event-driven mechanisms of controller runtime ControllerManager

- **renames**
- **rename ii**
- **tests working**
- **renames, update tests**
