### PR TITLE
add process-isolated parallel mode for knative parallel runs

### DIFF
--- a/docs/plans/2026-02-18-process-parallel-mode-serialization-design.md
+++ b/docs/plans/2026-02-18-process-parallel-mode-serialization-design.md
@@ -1,0 +1,133 @@
+# Process-Parallel Mode and Scenario Serialization Design
+
+## Objective
+Document the current `--parallel-mode=process` approach in Knative, explain its
+tradeoffs, and define a path to a serialized scenario manifest model.
+
+## Problem Context
+`simclock` uses package-global process state. Running multiple scenarios in a
+single process (goroutines) can couple clock/ticker state across runs and create
+non-deterministic interference. A process-isolated execution mode avoids this by
+giving each scenario its own process-level globals.
+
+## Current Implementation (as of 2026-02-18)
+Location:
+- `examples/knative-serving/main.go`
+- `examples/knative-serving/parallel_mode.go`
+
+Public flags:
+- `--parallel`
+- `--parallel-mode=goroutine|process` (default `goroutine`)
+- `--parallel-workers=<n>` (0 => `GOMAXPROCS`)
+
+Internal flags (parent -> child):
+- `--parallel-child=true`
+- `--scenario-index=<idx>`
+
+Execution flow:
+1. Parent resolves batch inputs (`--inputs` or default baseline when
+   `--parallel` is enabled).
+2. Parent expands inputs to scenarios (`scenariosFromInputs`).
+3. If mode is `goroutine`, run existing `ParallelRunner`.
+4. If mode is `process`, parent spawns child processes (`os/exec`) and passes
+   original CLI args plus child overrides.
+5. Child re-runs input loading + scenario expansion, selects one scenario by
+   `--scenario-index`, and executes only that scenario.
+
+Why this works:
+- Each scenario runs in a separate OS process, so global `simclock` state is
+  isolated without a large `simclock` refactor.
+- The parent still controls overall parallelism and failure propagation.
+
+## Tradeoffs in Current Approach
+
+### Pros
+- Minimal invasive change to existing runner code.
+- Strong process-level isolation for globals (`simclock` and similar).
+- Cross-platform behavior via `os/exec` (no fork-only assumptions).
+
+### Cons
+- Parent and child both expand scenarios. This duplicates work and increases
+  startup cost for larger scenario sets.
+- Correctness depends on deterministic re-expansion:
+  same args + same seed must produce identical scenario ordering and count.
+- Child selection by index is opaque and hard to inspect/debug after the fact.
+- Output naming can drift from parent indexing semantics because child runs one
+  local scenario at index `0`.
+- No stable artifact that records "exactly what scenarios were executed".
+
+### Risk Areas
+- Any future nondeterminism in scenario generation breaks index-based mapping.
+- Future harnesses with non-serializable closures/invariants in `Scenario` need
+  a clearer boundary between "scenario spec" and runtime-only fields.
+
+## Proposed Direction: Serialized Scenario Manifest
+
+### Design Goal
+Make process-mode selection explicit and reproducible by serializing expanded
+scenario specs once in the parent, then having children consume that artifact.
+
+### Core Idea
+Introduce a manifest file produced by the parent:
+- Parent does expansion once.
+- Parent writes `N` scenario specs to disk with stable ordering.
+- Child receives `--scenario-manifest=<path>` and `--scenario-index=<idx>`.
+- Child loads exactly one manifest entry and executes it.
+
+### Manifest Scope
+Manifest should encode data needed to reconstruct a runnable scenario without
+re-running high-level expansion logic.
+
+For Knative, include per scenario:
+- `name`
+- expanded `coverage.Input` (objects + pending)
+- resolved explore config/tuning values
+- optional context metadata (workflow, input ref, attributes)
+
+Do not serialize:
+- function pointers/closures (`Scenario.Invariant`)
+- runtime-only handles (`VersionManager`, stats pointers)
+
+### Example Shape (illustrative)
+```json
+{
+  "version": "v1",
+  "harness": "knative-serving",
+  "scenarios": [
+    {
+      "index": 0,
+      "name": "knative-default/base",
+      "input": { "...": "expanded coverage.Input" },
+      "config": { "...": "tracecheck.ExploreConfig" },
+      "context": { "...": "optional scenario context" }
+    }
+  ]
+}
+```
+
+## Benefits of Manifest Model
+- Eliminates parent/child scenario expansion drift.
+- Makes executed scenario set explicit, inspectable, and replayable.
+- Enables retrying individual scenarios by index from a persisted artifact.
+- Provides a foundation for future distributed workers (local or remote).
+
+## Costs and Constraints
+- Need manifest schema versioning and backward compatibility policy.
+- Large scenario inputs can produce large files (consider JSONL or compression).
+- Temporary file lifecycle/cleanup must be explicit.
+- Requires harness-specific adapters where scenario construction is custom.
+
+## Incremental Adoption Plan
+1. Keep existing index-recompute path as fallback.
+2. Add manifest write/read path behind process mode.
+3. Prefer manifest path by default in process mode once validated.
+4. Remove recompute path only after proving parity across representative runs.
+
+## Open Questions
+- Where should manifest files live by default (`/tmp`, dump dir sibling, or
+  explicit user path)?
+- Should we retain manifests automatically for debugging or clean them by
+  default?
+- Should parent aggregate per-child status into a summary report artifact?
+- Is a shared generic manifest format needed across harnesses now, or should we
+  start harness-local and converge later?

--- a/examples/knative-serving/main.go
+++ b/examples/knative-serving/main.go
@@ -29,8 +29,12 @@ import (
 var scheme = knativescheme.Default
 
 var parallelFlag = flag.Bool("parallel", false, "run parallel scenario mode; if --inputs is omitted, use built-in knative baseline inputs")
+var parallelModeFlag = flag.String("parallel-mode", "goroutine", "parallel execution mode: goroutine or process")
+var parallelWorkersFlag = flag.Int("parallel-workers", 0, "number of workers for parallel execution (0 uses GOMAXPROCS)")
 var fuzzCasesFlag = flag.Int("fuzz-cases", 20, "number of sampled parameterized scenarios to generate per input")
 var fuzzSeedFlag = flag.Int64("fuzz-seed", 1337, "seed for deterministic sampled parameterized scenario generation")
+var parallelChildFlag = flag.Bool("parallel-child", false, "internal: run a single batch scenario in child mode")
+var scenarioIndexFlag = flag.Int("scenario-index", -1, "internal: scenario index for child mode")
 
 type digestBypassResolver struct{}
 
@@ -164,6 +168,13 @@ func main() {
 		fmt.Fprintf(os.Stderr, "load inputs: %v\n", err)
 		os.Exit(1)
 	}
+	if *parallelChildFlag {
+		if err := runParallelChild(ctx, builder, inputs, batchMode); err != nil {
+			fmt.Fprintf(os.Stderr, "child run error: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
 	if batchMode {
 		if explore.InteractiveEnabled() {
 			fmt.Fprintln(os.Stderr, "interactive ignored in batch mode")
@@ -174,13 +185,7 @@ func main() {
 			fmt.Fprintf(os.Stderr, "convert inputs: %v\n", err)
 			os.Exit(1)
 		}
-		runner, err := explore.NewParallelRunner(builder)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "runner setup error: %v\n", err)
-			os.Exit(1)
-		}
-		opts := explore.ParallelOptions{DumpDir: explore.DumpPath(), StatsDir: explore.DumpStatsPath()}
-		if _, err := runner.RunAll(ctx, scenarios, opts); err != nil {
+		if _, err := runBatchScenarios(ctx, builder, scenarios); err != nil {
 			fmt.Fprintf(os.Stderr, "batch run error: %v\n", err)
 			os.Exit(1)
 		}

--- a/examples/knative-serving/parallel_mode.go
+++ b/examples/knative-serving/parallel_mode.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"sync"
+
+	"github.com/tgoodwin/kamera/pkg/coverage"
+	"github.com/tgoodwin/kamera/pkg/explore"
+	"github.com/tgoodwin/kamera/pkg/tracecheck"
+)
+
+type parallelMode string
+
+const (
+	parallelModeGoroutine parallelMode = "goroutine"
+	parallelModeProcess   parallelMode = "process"
+)
+
+func parseParallelMode(raw string) (parallelMode, error) {
+	mode := parallelMode(strings.ToLower(strings.TrimSpace(raw)))
+	if mode == "" {
+		return parallelModeGoroutine, nil
+	}
+	switch mode {
+	case parallelModeGoroutine, parallelModeProcess:
+		return mode, nil
+	default:
+		return "", fmt.Errorf("invalid --parallel-mode %q (expected goroutine or process)", raw)
+	}
+}
+
+func scenariosForChildIndex(scenarios []explore.Scenario, idx int) ([]explore.Scenario, error) {
+	if idx < 0 {
+		return scenarios, nil
+	}
+	if idx >= len(scenarios) {
+		return nil, fmt.Errorf("scenario-index %d out of range", idx)
+	}
+	return []explore.Scenario{scenarios[idx]}, nil
+}
+
+func buildParallelChildArgs(baseArgs []string, scenarioIdx int) []string {
+	args := append([]string{}, baseArgs...)
+	args = append(args,
+		"--parallel-child=true",
+		fmt.Sprintf("--scenario-index=%d", scenarioIdx),
+		"--parallel-mode=goroutine",
+		"--interactive=false",
+	)
+	return args
+}
+
+func runParallelChild(ctx context.Context, builder *tracecheck.ExplorerBuilder, inputs []coverage.Input, batchMode bool) error {
+	if !batchMode {
+		return fmt.Errorf("--parallel-child requires batch mode")
+	}
+	if *scenarioIndexFlag < 0 {
+		return fmt.Errorf("--parallel-child requires --scenario-index")
+	}
+
+	scenarios, err := scenariosFromInputs(builder, inputs)
+	if err != nil {
+		return fmt.Errorf("convert inputs: %w", err)
+	}
+	selected, err := scenariosForChildIndex(scenarios, *scenarioIndexFlag)
+	if err != nil {
+		return err
+	}
+	_, err = runBatchScenariosGoroutine(ctx, builder, selected, 1)
+	return err
+}
+
+func runBatchScenarios(ctx context.Context, builder *tracecheck.ExplorerBuilder, scenarios []explore.Scenario) ([]explore.ScenarioResult, error) {
+	mode, err := parseParallelMode(*parallelModeFlag)
+	if err != nil {
+		return nil, err
+	}
+	if *parallelWorkersFlag < 0 {
+		return nil, fmt.Errorf("--parallel-workers must be >= 0")
+	}
+
+	if mode == parallelModeProcess && !*parallelChildFlag {
+		return runBatchScenariosProcess(ctx, scenarios)
+	}
+
+	workers := *parallelWorkersFlag
+	if *parallelChildFlag && workers == 0 {
+		workers = 1
+	}
+	return runBatchScenariosGoroutine(ctx, builder, scenarios, workers)
+}
+
+func runBatchScenariosGoroutine(ctx context.Context, builder *tracecheck.ExplorerBuilder, scenarios []explore.Scenario, workers int) ([]explore.ScenarioResult, error) {
+	runner, err := explore.NewParallelRunner(builder)
+	if err != nil {
+		return nil, fmt.Errorf("runner setup error: %w", err)
+	}
+	opts := explore.ParallelOptions{
+		MaxParallel: workers,
+		DumpDir:     explore.DumpPath(),
+		StatsDir:    explore.DumpStatsPath(),
+	}
+	return runner.RunAll(ctx, scenarios, opts)
+}
+
+func runBatchScenariosProcess(ctx context.Context, scenarios []explore.Scenario) ([]explore.ScenarioResult, error) {
+	results := make([]explore.ScenarioResult, len(scenarios))
+	if len(scenarios) == 0 {
+		return results, nil
+	}
+
+	exePath, err := os.Executable()
+	if err != nil {
+		return nil, fmt.Errorf("resolve executable: %w", err)
+	}
+
+	workers := *parallelWorkersFlag
+	if workers == 0 {
+		workers = runtime.GOMAXPROCS(0)
+	}
+	if workers > len(scenarios) {
+		workers = len(scenarios)
+	}
+	if workers <= 0 {
+		workers = 1
+	}
+
+	type runResult struct {
+		idx int
+		err error
+	}
+
+	childCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	baseArgs := os.Args[1:]
+	jobs := make(chan int)
+	resCh := make(chan runResult, len(scenarios))
+
+	var wg sync.WaitGroup
+	worker := func() {
+		defer wg.Done()
+		for idx := range jobs {
+			args := buildParallelChildArgs(baseArgs, idx)
+			cmd := exec.CommandContext(childCtx, exePath, args...)
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			err := cmd.Run()
+			resCh <- runResult{idx: idx, err: err}
+			if err != nil {
+				cancel()
+			}
+		}
+	}
+
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go worker()
+	}
+
+	for idx := range scenarios {
+		jobs <- idx
+	}
+	close(jobs)
+
+	go func() {
+		wg.Wait()
+		close(resCh)
+	}()
+
+	var firstErr error
+	for item := range resCh {
+		results[item.idx] = explore.ScenarioResult{Name: scenarios[item.idx].Name, Err: item.err}
+		if item.err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("scenario %q failed: %w", scenarios[item.idx].Name, item.err)
+		}
+	}
+
+	return results, firstErr
+}

--- a/examples/knative-serving/parallel_mode_test.go
+++ b/examples/knative-serving/parallel_mode_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tgoodwin/kamera/pkg/explore"
+)
+
+func TestParseParallelModeDefaultsToGoroutine(t *testing.T) {
+	mode, err := parseParallelMode("")
+	if err != nil {
+		t.Fatalf("parseParallelMode error = %v", err)
+	}
+	if mode != parallelModeGoroutine {
+		t.Fatalf("expected %q, got %q", parallelModeGoroutine, mode)
+	}
+}
+
+func TestParseParallelModeAcceptsProcess(t *testing.T) {
+	mode, err := parseParallelMode("PROCESS")
+	if err != nil {
+		t.Fatalf("parseParallelMode error = %v", err)
+	}
+	if mode != parallelModeProcess {
+		t.Fatalf("expected %q, got %q", parallelModeProcess, mode)
+	}
+}
+
+func TestParseParallelModeRejectsUnknown(t *testing.T) {
+	_, err := parseParallelMode("threads")
+	if err == nil {
+		t.Fatal("expected error for invalid mode")
+	}
+	if !strings.Contains(err.Error(), "invalid --parallel-mode") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestScenariosForChildIndexAllScenariosWhenUnset(t *testing.T) {
+	scenarios := []explore.Scenario{{Name: "a"}, {Name: "b"}}
+	got, err := scenariosForChildIndex(scenarios, -1)
+	if err != nil {
+		t.Fatalf("scenariosForChildIndex error = %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 scenarios, got %d", len(got))
+	}
+}
+
+func TestScenariosForChildIndexSelectsSingleScenario(t *testing.T) {
+	scenarios := []explore.Scenario{{Name: "a"}, {Name: "b"}}
+	got, err := scenariosForChildIndex(scenarios, 1)
+	if err != nil {
+		t.Fatalf("scenariosForChildIndex error = %v", err)
+	}
+	if len(got) != 1 || got[0].Name != "b" {
+		t.Fatalf("unexpected scenarios: %#v", got)
+	}
+}
+
+func TestScenariosForChildIndexRejectsOutOfRange(t *testing.T) {
+	scenarios := []explore.Scenario{{Name: "a"}}
+	_, err := scenariosForChildIndex(scenarios, 1)
+	if err == nil {
+		t.Fatal("expected out-of-range error")
+	}
+	if !strings.Contains(err.Error(), "scenario-index 1 out of range") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestBuildParallelChildArgsAppendsOverrides(t *testing.T) {
+	args := buildParallelChildArgs([]string{"--parallel", "--fuzz-cases=10"}, 7)
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "--parallel-child=true") {
+		t.Fatalf("expected child mode override in args: %q", joined)
+	}
+	if !strings.Contains(joined, "--scenario-index=7") {
+		t.Fatalf("expected scenario index override in args: %q", joined)
+	}
+	if !strings.Contains(joined, "--parallel-mode=goroutine") {
+		t.Fatalf("expected goroutine override in args: %q", joined)
+	}
+	if !strings.Contains(joined, "--interactive=false") {
+		t.Fatalf("expected interactive override in args: %q", joined)
+	}
+}


### PR DESCRIPTION
## Summary
- add parallel-mode and parallel-workers flags to knative-serving batch execution
- implement process-isolated scenario execution via parent/child subprocess orchestration with internal child/index flags
- add unit tests for mode parsing, child index selection, and child argument wiring
- add a design note documenting current tradeoffs and a scenario-manifest serialization direction

## Test Plan
- go test ./... (from examples/knative-serving)
