### PR TITLE
Implement interval-based staleness model

### DIFF
--- a/examples/crossplane/interval_composition-update-races-xr-fetch.json
+++ b/examples/crossplane/interval_composition-update-races-xr-fetch.json
@@ -1,0 +1,157 @@
+[
+  {
+    "name": "crossplane-staleness/composition-update-races-xr-fetch-intervals",
+    "environmentState": {
+      "objects": [
+        {
+          "apiVersion": "pkg.crossplane.io/v1",
+          "kind": "FunctionRevision",
+          "metadata": {
+            "name": "kamera-stub-rev",
+            "labels": {
+              "pkg.crossplane.io/package": "kamera-stub"
+            }
+          },
+          "spec": {
+            "desiredState": "Active"
+          },
+          "status": {
+            "capabilities": [
+              "composition"
+            ]
+          }
+        },
+        {
+          "apiVersion": "apiextensions.crossplane.io/v1",
+          "kind": "Composition",
+          "metadata": {
+            "name": "widget-composition"
+          },
+          "spec": {
+            "compositeTypeRef": {
+              "apiVersion": "example.org/v1",
+              "kind": "XWidget"
+            },
+            "mode": "Pipeline",
+            "pipeline": [
+              {
+                "step": "pipeline",
+                "functionRef": {
+                  "name": "kamera-stub"
+                }
+              }
+            ],
+            "writeConnectionSecretsToNamespace": "default"
+          }
+        },
+        {
+          "apiVersion": "apiextensions.crossplane.io/v1",
+          "kind": "CompositionRevision",
+          "metadata": {
+            "name": "widget-composition-rev-1",
+            "labels": {
+              "crossplane.io/composition-name": "widget-composition"
+            },
+            "ownerReferences": [
+              {
+                "apiVersion": "apiextensions.crossplane.io/v1",
+                "kind": "Composition",
+                "name": "widget-composition",
+                "uid": "331xxcxr",
+                "controller": true
+              }
+            ]
+          },
+          "spec": {
+            "compositeTypeRef": {
+              "apiVersion": "example.org/v1",
+              "kind": "XWidget"
+            },
+            "mode": "Pipeline",
+            "pipeline": [
+              {
+                "step": "pipeline",
+                "functionRef": {
+                  "name": "kamera-stub"
+                }
+              }
+            ],
+            "writeConnectionSecretsToNamespace": "default",
+            "revision": 1
+          },
+          "status": {
+            "conditions": [
+              {
+                "type": "ValidPipeline",
+                "status": "True",
+                "reason": "ValidPipeline"
+              }
+            ]
+          }
+        },
+        {
+          "apiVersion": "example.org/v1",
+          "kind": "XWidget",
+          "metadata": {
+            "name": "example",
+            "namespace": "default"
+          },
+          "spec": {
+            "compositionRef": {
+              "name": "widget-composition"
+            },
+            "compositionRevisionRef": {
+              "name": "widget-composition-rev-1"
+            },
+            "compositionUpdatePolicy": "Automatic"
+          }
+        }
+      ]
+    },
+    "tuning": {
+      "maxDepth": 100,
+      "permuteControllers": [
+        "CompositeReconciler",
+        "CompositionReconciler"
+      ],
+      "stalenessIntervals": [
+        {
+          "reconciler": "CompositionReconciler",
+          "kind": "apiextensions.crossplane.io/CompositionRevision",
+          "staleAt": 6,
+          "catchUpAt": 10,
+          "lag": -1
+        }
+      ]
+    },
+    "userInputs": [
+      {
+        "id": "update composition while xr is bound",
+        "type": "UPDATE",
+        "object": {
+          "apiVersion": "apiextensions.crossplane.io/v1",
+          "kind": "Composition",
+          "metadata": {
+            "name": "widget-composition"
+          },
+          "spec": {
+            "compositeTypeRef": {
+              "apiVersion": "example.org/v1",
+              "kind": "XWidget"
+            },
+            "mode": "Pipeline",
+            "pipeline": [
+              {
+                "step": "pipeline",
+                "functionRef": {
+                  "name": "kamera-stub"
+                }
+              }
+            ],
+            "writeConnectionSecretsToNamespace": "crossplane-system"
+          }
+        }
+      }
+    ]
+  }
+]

--- a/examples/crossplane/interval_function-capability-removed.json
+++ b/examples/crossplane/interval_function-capability-removed.json
@@ -1,0 +1,153 @@
+[
+  {
+    "name": "crossplane-staleness/function-capability-removed-intervals",
+    "environmentState": {
+      "objects": [
+        {
+          "apiVersion": "pkg.crossplane.io/v1",
+          "kind": "FunctionRevision",
+          "metadata": {
+            "name": "kamera-stub-rev",
+            "labels": {
+              "pkg.crossplane.io/package": "kamera-stub"
+            }
+          },
+          "spec": {
+            "desiredState": "Active"
+          },
+          "status": {
+            "capabilities": [
+              "composition"
+            ]
+          }
+        },
+        {
+          "apiVersion": "apiextensions.crossplane.io/v1",
+          "kind": "Composition",
+          "metadata": {
+            "name": "widget-composition"
+          },
+          "spec": {
+            "compositeTypeRef": {
+              "apiVersion": "example.org/v1",
+              "kind": "XWidget"
+            },
+            "mode": "Pipeline",
+            "pipeline": [
+              {
+                "step": "pipeline",
+                "functionRef": {
+                  "name": "kamera-stub"
+                }
+              }
+            ],
+            "writeConnectionSecretsToNamespace": "default"
+          }
+        },
+        {
+          "apiVersion": "apiextensions.crossplane.io/v1",
+          "kind": "CompositionRevision",
+          "metadata": {
+            "name": "widget-composition-rev-1",
+            "labels": {
+              "crossplane.io/composition-name": "widget-composition"
+            },
+            "ownerReferences": [
+              {
+                "apiVersion": "apiextensions.crossplane.io/v1",
+                "kind": "Composition",
+                "name": "widget-composition",
+                "uid": "331xxcxr",
+                "controller": true
+              }
+            ]
+          },
+          "spec": {
+            "compositeTypeRef": {
+              "apiVersion": "example.org/v1",
+              "kind": "XWidget"
+            },
+            "mode": "Pipeline",
+            "pipeline": [
+              {
+                "step": "pipeline",
+                "functionRef": {
+                  "name": "kamera-stub"
+                }
+              }
+            ],
+            "writeConnectionSecretsToNamespace": "default",
+            "revision": 1
+          },
+          "status": {
+            "conditions": [
+              {
+                "type": "ValidPipeline",
+                "status": "True",
+                "reason": "ValidPipeline"
+              }
+            ]
+          }
+        },
+        {
+          "apiVersion": "example.org/v1",
+          "kind": "XWidget",
+          "metadata": {
+            "name": "example",
+            "namespace": "default"
+          },
+          "spec": {
+            "compositionRef": {
+              "name": "widget-composition"
+            },
+            "compositionRevisionRef": {
+              "name": "widget-composition-rev-1"
+            },
+            "compositionUpdatePolicy": "Automatic"
+          }
+        }
+      ]
+    },
+    "tuning": {
+      "maxDepth": 100,
+      "permuteControllers": [
+        "CompositeReconciler",
+        "CompositionRevisionReconciler"
+      ],
+      "stalenessIntervals": [
+        {
+          "reconciler": "CompositionRevisionReconciler",
+          "kind": "pkg.crossplane.io/FunctionRevision",
+          "staleAt": 1,
+          "catchUpAt": 4,
+          "lag": -1
+        }
+      ],
+      "userActionReadyDepths": {
+        "0": 0
+      }
+    },
+    "userInputs": [
+      {
+        "id": "remove composition capability from function",
+        "type": "UPDATE",
+        "object": {
+          "apiVersion": "pkg.crossplane.io/v1",
+          "kind": "FunctionRevision",
+          "metadata": {
+            "name": "kamera-stub-rev",
+            "labels": {
+              "pkg.crossplane.io/package": "kamera-stub"
+            }
+          },
+          "spec": {
+            "desiredState": "Active"
+          },
+          "status": {
+            "capabilities": []
+          }
+        }
+      }
+    ]
+  }
+]

--- a/examples/crossplane/scenario.go
+++ b/examples/crossplane/scenario.go
@@ -374,5 +374,18 @@ func applyInputTuning(base tracecheck.ExploreConfig, tuning coverage.InputTuning
 			cfg.Perturbations.Staleness[id] = st
 		}
 	}
+	if len(tuning.StalenessIntervals) > 0 {
+		intervals := make([]tracecheck.StalenessInterval, 0, len(tuning.StalenessIntervals))
+		for _, si := range tuning.StalenessIntervals {
+			intervals = append(intervals, tracecheck.StalenessInterval{
+				ReconcilerID: tracecheck.ReconcilerID(si.Reconciler),
+				Kind:         si.Kind,
+				StaleAt:      si.StaleAt,
+				CatchUpAt:    si.CatchUpAt,
+				Lag:          si.Lag,
+			})
+		}
+		cfg.Perturbations.StalenessIntervals = intervals
+	}
 	return cfg
 }

--- a/pkg/coverage/types.go
+++ b/pkg/coverage/types.go
@@ -25,13 +25,23 @@ type UserInput struct {
 	Object *unstructured.Unstructured `json:"object"`
 }
 
+// InputStalenessInterval is the JSON-facing staleness interval configuration.
+type InputStalenessInterval struct {
+	Reconciler string `json:"reconciler"`
+	Kind       string `json:"kind"`
+	StaleAt    int64  `json:"staleAt"`
+	CatchUpAt  int64  `json:"catchUpAt"`
+	Lag        int64  `json:"lag"`
+}
+
 // InputTuning carries compact hints for later ExploreConfig construction.
 type InputTuning struct {
-	MaxDepth           int                 `json:"maxDepth"`
-	PermuteControllers []string            `json:"permuteControllers"`
-	StaleReads         map[string][]string `json:"staleReads"`
-	StaleLookback      map[string]int      `json:"staleLookback"`
-	Search             InputSearchTuning   `json:"search"`
+	MaxDepth           int                      `json:"maxDepth"`
+	PermuteControllers []string                 `json:"permuteControllers"`
+	StaleReads         map[string][]string      `json:"staleReads"`
+	StaleLookback      map[string]int           `json:"staleLookback"`
+	StalenessIntervals []InputStalenessInterval `json:"stalenessIntervals"`
+	Search             InputSearchTuning        `json:"search"`
 }
 
 // InputSearchTuning carries optional per-input search-mode overrides.

--- a/pkg/explore/parallel_runner.go
+++ b/pkg/explore/parallel_runner.go
@@ -441,6 +441,7 @@ func (r *ParallelRunner) runScenario(ctx context.Context, scenario Scenario, opt
 		// This intentionally favors "get end-to-end scaffolding running" over
 		// precision/attribution. Harnesses can still override with ClosedLoop.Plan.
 		referenceConfig = disablePerturbations(scenario.Config)
+		hasExplicitStaleness := len(scenario.Config.Perturbations.Staleness) > 0
 		planFn = func(reference ScenarioPhaseResult) ([]ScenarioPhasePlan, error) {
 			var plans []ScenarioPhasePlan
 			if len(scenario.UserInputs) >= 2 {
@@ -448,7 +449,14 @@ func (r *ParallelRunner) runScenario(ctx context.Context, scenario Scenario, opt
 			} else {
 				plans = append(plans, buildDefaultScenarioRerunPlans(reference, scenario.Config, scenario.Context)...)
 			}
-			plans = append(plans, buildStalenessPerturbationPlans(reference, scenario.Config, scenario.Context)...)
+			if hasExplicitStaleness {
+				// Workflow JSON specified targeted staleness config; honor it
+				// in a dedicated rerun phase.
+				plans = append(plans, buildExplicitStalenessPlans(reference, scenario.Config, scenario.Context)...)
+			} else {
+				// No explicit staleness; auto-derive from reference trace reads.
+				plans = append(plans, buildStalenessPerturbationPlans(reference, scenario.Config, scenario.Context)...)
+			}
 			return plans, nil
 		}
 	} else if scenario.ClosedLoop.Plan != nil {
@@ -495,6 +503,8 @@ func (r *ParallelRunner) runScenario(ctx context.Context, scenario Scenario, opt
 func disablePerturbations(cfg tracecheck.ExploreConfig) tracecheck.ExploreConfig {
 	// Naive baseline utility used by v1 auto closed-loop:
 	// treat reference runs as "control" by clearing all perturbation knobs.
+	// UserActionReadyDepths is preserved because it is scheduling metadata,
+	// not a perturbation that should be toggled for controlled experiments.
 	out := cfg.Clone()
 	if out.Perturbations.PermuteOrder == nil {
 		out.Perturbations.PermuteOrder = make(map[tracecheck.ReconcilerID]bool)
@@ -503,7 +513,9 @@ func disablePerturbations(cfg tracecheck.ExploreConfig) tracecheck.ExploreConfig
 		out.Perturbations.PermuteOrder[id] = false
 	}
 	out.Perturbations.Staleness = make(map[tracecheck.ReconcilerID]tracecheck.StalenessConfig)
-	out.Perturbations.UserActionReadyDepths = make(map[int]int)
+	if out.Perturbations.UserActionReadyDepths == nil {
+		out.Perturbations.UserActionReadyDepths = make(map[int]int)
+	}
 	return out
 }
 
@@ -688,6 +700,40 @@ func observedReadKindsPerController(reference ScenarioPhaseResult) map[tracechec
 		out[id] = sorted
 	}
 	return out
+}
+
+// buildExplicitStalenessPlans creates a rerun phase using the staleness config
+// from the workflow JSON directly, rather than auto-deriving from the reference
+// trace. This honors targeted staleness tuning (specific controllers, kinds,
+// and lookback values) specified by the workflow author. Ordering permutation
+// for all controllers observed in the reference is also enabled.
+func buildExplicitStalenessPlans(
+	reference ScenarioPhaseResult,
+	base tracecheck.ExploreConfig,
+	scenarioCtx ScenarioContext,
+) []ScenarioPhasePlan {
+	cfg := base.Clone()
+	// Enable ordering permutation for all controllers observed in the reference.
+	seenControllers := observedControllersInReference(reference)
+	if cfg.Perturbations.PermuteOrder == nil {
+		cfg.Perturbations.PermuteOrder = make(map[tracecheck.ReconcilerID]bool)
+	}
+	for _, controllerID := range seenControllers {
+		if controllerID == "" || controllerID == tracecheck.UserControllerID {
+			continue
+		}
+		cfg.Perturbations.PermuteOrder[controllerID] = true
+	}
+	// Staleness config is already set from applyInputTuning via scenario.Config.
+
+	rerunContext := scenarioCtx
+	return []ScenarioPhasePlan{
+		{
+			Name:    "rerun",
+			Config:  cfg,
+			Context: &rerunContext,
+		},
+	}
 }
 
 func buildStalenessPerturbationPlans(

--- a/pkg/test/integration/staleness_interval_test.go
+++ b/pkg/test/integration/staleness_interval_test.go
@@ -1,0 +1,263 @@
+package test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	foov1 "github.com/tgoodwin/kamera/pkg/test/integration/api/v1"
+	"github.com/tgoodwin/kamera/pkg/test/integration/controller"
+	"github.com/tgoodwin/kamera/pkg/tracecheck"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+// buildFooBarWithIntervals sets up FooController (FooReconciler, mode-driven
+// state machine) and BarController (BarReconciler, flips mode A→B at "A-1")
+// with optional staleness intervals. This is the same two-controller scenario
+// as TestConvergedStateIdentification, extracted for staleness testing.
+func buildFooBarWithIntervals(t *testing.T, intervals []tracecheck.StalenessInterval) (*tracecheck.Explorer, tracecheck.StateNode) {
+	t.Helper()
+
+	eb := tracecheck.NewExplorerBuilder(scheme)
+	eb.WithMaxDepth(15)
+	eb.WithoutOptimizations()
+
+	fooKind := "webapp.discrete.events/Foo"
+	eb.WithReconciler("FooController", func(c ctrlclient.Client) tracecheck.Reconciler {
+		return &controller.FooReconciler{Client: c, Scheme: scheme}
+	}).For(fooKind)
+
+	eb.WithReconciler("BarController", func(c ctrlclient.Client) tracecheck.Reconciler {
+		return &controller.BarReconciler{Client: c, Scheme: scheme}
+	}).For(fooKind)
+
+	setExplorePermuteConfig(eb, map[tracecheck.ReconcilerID]bool{
+		"FooController": true,
+		"BarController": true,
+	})
+
+	if len(intervals) > 0 {
+		cfg := eb.Config()
+		cfg.Perturbations.StalenessIntervals = intervals
+		eb.SetConfig(cfg)
+	}
+
+	topLevelObj := &foov1.Foo{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "default",
+			Labels: map[string]string{
+				"tracey-uid":                       "foo",
+				"discrete.events/sleeve-object-id": "foo-123",
+			},
+		},
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "webapp.discrete.events/v1",
+			Kind:       "Foo",
+		},
+		Spec: foov1.FooSpec{Mode: "A"},
+	}
+
+	sb := eb.NewStateEventBuilder()
+	initialState := sb.AddTopLevelObject(topLevelObj, "FooController", "BarController")
+	initialState.Contents.KindSequences = canonicalizeKindSequences(initialState.Contents.KindSequences)
+
+	explorer, err := eb.Build()
+	require.NoError(t, err)
+
+	return explorer, initialState
+}
+
+// collectStalenessInfo gathers all StaleReadInfo entries across all paths
+// in the given converged states.
+func collectStalenessInfo(states []tracecheck.ResultState) []tracecheck.StaleReadInfo {
+	var all []tracecheck.StaleReadInfo
+	for _, s := range states {
+		for _, path := range s.Paths {
+			for _, step := range path {
+				all = append(all, step.StalenessInfo...)
+			}
+		}
+	}
+	return all
+}
+
+// countReconcilerSteps returns how many steps in the execution history belong
+// to the given reconciler, across all paths in all converged states.
+func countReconcilerSteps(states []tracecheck.ResultState, reconcilerID tracecheck.ReconcilerID) int {
+	count := 0
+	for _, s := range states {
+		for _, path := range s.Paths {
+			for _, step := range path {
+				if step.ControllerID == reconcilerID {
+					count++
+				}
+			}
+		}
+	}
+	return count
+}
+
+func setupStalenessTestLogger(t *testing.T) {
+	t.Helper()
+	opts := zap.Options{Development: true}
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+	tracecheck.SetLogger(ctrl.Log.WithName("tracecheck").V(2))
+}
+
+// TestStalenessInterval_Baseline establishes the reference behavior:
+// FooController + BarController without intervals produces 2 converged states
+// (A-Final and B-Final) because BarController can flip mode at "A-1".
+func TestStalenessInterval_Baseline(t *testing.T) {
+	setupStalenessTestLogger(t)
+
+	explorer, initialState := buildFooBarWithIntervals(t, nil)
+	result := explorer.Explore(context.Background(), initialState)
+
+	require.Len(t, result.ConvergedStates, 2, "baseline should produce A-Final and B-Final")
+
+	foundAFinal, foundBFinal := false, false
+	for _, cs := range result.ConvergedStates {
+		status, hasAnnotation, ok := summarizeState(cs, explorer.VersionManager())
+		require.True(t, ok, "should be able to summarize converged state")
+		if status == "A-Final" && !hasAnnotation {
+			foundAFinal = true
+		}
+		if status == "B-Final" && hasAnnotation {
+			foundBFinal = true
+		}
+	}
+	assert.True(t, foundAFinal, "expected A-Final converged state")
+	assert.True(t, foundBFinal, "expected B-Final converged state from mode flip")
+
+	staleness := collectStalenessInfo(result.ConvergedStates)
+	assert.Empty(t, staleness, "no staleness expected without intervals")
+}
+
+// TestStalenessInterval_FrozenReconcilerPreventsModeFlip verifies that
+// freezing BarController's view of Foo eliminates the B-Final convergence path.
+//
+// BarController normally flips Foo's mode from A→B when it sees status "A-1".
+// With a staleness interval freezing BarController at the initial kind sequence,
+// it never observes the "A-1" transition. The mode flip never fires, and only
+// A-Final is reachable — regardless of controller ordering (permutation).
+func TestStalenessInterval_FrozenReconcilerPreventsModeFlip(t *testing.T) {
+	setupStalenessTestLogger(t)
+
+	intervals := []tracecheck.StalenessInterval{{
+		ReconcilerID: "BarController",
+		Kind:         "webapp.discrete.events/Foo",
+		StaleAt:      1,
+		CatchUpAt:    8, // wide window covering all transitions
+		Lag:          -1, // frozen at initial sequence
+	}}
+
+	explorer, initialState := buildFooBarWithIntervals(t, intervals)
+	result := explorer.Explore(context.Background(), initialState)
+
+	// With BarController frozen, it never sees "A-1" → no mode flip → only A-Final.
+	require.Len(t, result.ConvergedStates, 1, "frozen BarController should prevent B-Final")
+
+	status, hasAnnotation, ok := summarizeState(result.ConvergedStates[0], explorer.VersionManager())
+	require.True(t, ok)
+	assert.Equal(t, "A-Final", status, "only A-Final should be reachable")
+	assert.False(t, hasAnnotation, "no mode-flip-done annotation expected")
+}
+
+// TestStalenessInterval_StalenessInfoPopulated verifies that ReconcileResults
+// carry StalenessInfo with correct details when a reconciler operates on stale data.
+func TestStalenessInterval_StalenessInfoPopulated(t *testing.T) {
+	setupStalenessTestLogger(t)
+
+	intervals := []tracecheck.StalenessInterval{{
+		ReconcilerID: "BarController",
+		Kind:         "webapp.discrete.events/Foo",
+		StaleAt:      1,
+		CatchUpAt:    8,
+		Lag:          -1,
+	}}
+
+	explorer, initialState := buildFooBarWithIntervals(t, intervals)
+	result := explorer.Explore(context.Background(), initialState)
+
+	staleness := collectStalenessInfo(result.ConvergedStates)
+	require.NotEmpty(t, staleness, "expected staleness info for frozen BarController")
+
+	for _, si := range staleness {
+		assert.Contains(t, si.Key, "Foo", "staleness should reference Foo objects")
+		assert.Greater(t, si.Lag, int64(0), "lag should be positive (controller saw older version)")
+		assert.Less(t, si.ObservedRV, si.CurrentRV, "observed RV should be behind current")
+	}
+}
+
+// TestStalenessInterval_TriggerFilteringReducesBarActivity verifies that
+// trigger filtering prevents BarController from being re-triggered by Foo
+// changes while it is stale. Compared to the baseline (no intervals),
+// BarController should execute fewer steps.
+func TestStalenessInterval_TriggerFilteringReducesBarActivity(t *testing.T) {
+	setupStalenessTestLogger(t)
+
+	// Baseline: count BarController steps without intervals.
+	explorer, initialState := buildFooBarWithIntervals(t, nil)
+	baselineResult := explorer.Explore(context.Background(), initialState)
+	baselineBarSteps := countReconcilerSteps(baselineResult.ConvergedStates, "BarController")
+
+	// With intervals: BarController is stale on Foo, so trigger filtering
+	// prevents re-triggering during the window.
+	intervals := []tracecheck.StalenessInterval{{
+		ReconcilerID: "BarController",
+		Kind:         "webapp.discrete.events/Foo",
+		StaleAt:      1,
+		CatchUpAt:    8,
+		Lag:          -1,
+	}}
+	explorer2, initialState2 := buildFooBarWithIntervals(t, intervals)
+	intervalResult := explorer2.Explore(context.Background(), initialState2)
+	intervalBarSteps := countReconcilerSteps(intervalResult.ConvergedStates, "BarController")
+
+	assert.Less(t, intervalBarSteps, baselineBarSteps,
+		"BarController should run fewer times when stale (trigger filtering active): got %d vs baseline %d",
+		intervalBarSteps, baselineBarSteps)
+}
+
+// TestStalenessInterval_WindowOutsideRange verifies that a staleness window
+// that never activates (staleAt far beyond actual kind sequences) produces
+// the same convergence behavior as the baseline.
+func TestStalenessInterval_WindowOutsideRange(t *testing.T) {
+	setupStalenessTestLogger(t)
+
+	intervals := []tracecheck.StalenessInterval{{
+		ReconcilerID: "BarController",
+		Kind:         "webapp.discrete.events/Foo",
+		StaleAt:      50,
+		CatchUpAt:    100,
+		Lag:          -1,
+	}}
+
+	explorer, initialState := buildFooBarWithIntervals(t, intervals)
+	result := explorer.Explore(context.Background(), initialState)
+
+	// Window never activates — should match baseline: 2 converged states.
+	require.Len(t, result.ConvergedStates, 2,
+		"inactive window should not affect convergence")
+
+	foundAFinal, foundBFinal := false, false
+	for _, cs := range result.ConvergedStates {
+		status, _, ok := summarizeState(cs, explorer.VersionManager())
+		if ok && status == "A-Final" {
+			foundAFinal = true
+		}
+		if ok && status == "B-Final" {
+			foundBFinal = true
+		}
+	}
+	assert.True(t, foundAFinal, "expected A-Final")
+	assert.True(t, foundBFinal, "expected B-Final (window inactive)")
+
+	staleness := collectStalenessInfo(result.ConvergedStates)
+	assert.Empty(t, staleness, "no staleness when window is outside sequence range")
+}

--- a/pkg/tracecheck/explore.go
+++ b/pkg/tracecheck/explore.go
@@ -39,6 +39,16 @@ type EffectContextManager interface {
 	CleanupEffectContext(ctx context.Context)
 }
 
+// StalenessInterval defines a window during which a reconciler's view
+// of a specific resource kind lags behind the actual cluster state.
+type StalenessInterval struct {
+	ReconcilerID ReconcilerID `json:"reconciler"`
+	Kind         string       `json:"kind"`  // canonical group/kind
+	StaleAt      int64        `json:"staleAt"`
+	CatchUpAt    int64        `json:"catchUpAt"`
+	Lag          int64        `json:"lag"` // how far behind frontier; -1 = frozen at StaleAt sequence
+}
+
 type PerturbationConfig struct {
 	PermuteOrder map[ReconcilerID]bool
 	Staleness    map[ReconcilerID]StalenessConfig
@@ -47,6 +57,11 @@ type PerturbationConfig struct {
 	// triggered reactively by prior controller output, so the explorer needs an
 	// explicit depth-based scheduler for them.
 	UserActionReadyDepths map[int]int
+
+	// StalenessIntervals defines declarative windows during which a reconciler's
+	// view of a specific resource kind lags behind actual cluster state. When
+	// configured, this replaces the per-step branching approach of the Staleness map.
+	StalenessIntervals []StalenessInterval `json:"stalenessIntervals,omitempty"`
 }
 
 type StalenessConfig struct {
@@ -159,6 +174,7 @@ func (cfg ExploreConfig) Clone() ExploreConfig {
 		copied.StaleReadBounds = maps.Clone(st.StaleReadBounds)
 		out.Perturbations.Staleness[id] = copied
 	}
+	out.Perturbations.StalenessIntervals = slices.Clone(cfg.Perturbations.StalenessIntervals)
 	return out
 }
 
@@ -569,6 +585,12 @@ func (e *Explorer) enqueueState(queue []StateNode, state StateNode) []StateNode 
 
 func (e *Explorer) Explore(ctx context.Context, initialState StateNode) *Result {
 	logger.Info("starting!")
+
+	// Stamp interval-based staleness config onto the initial state so it
+	// propagates to all descendant states via materializeNextState.
+	if len(e.Config.Perturbations.StalenessIntervals) > 0 {
+		initialState.stalenessIntervals = e.Config.Perturbations.StalenessIntervals
+	}
 
 	exploreCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -1376,9 +1398,13 @@ func (e *Explorer) materializeNextState(
 	stepResult.KindSeqBefore = maps.Clone(stateView.Contents.KindSequences)
 
 	// Compute staleness info when the controller observed a stale view.
-	if consumed != nil && stateView.stuckReconcilerPositions != nil {
-		if stuckSeqs, stuck := stateView.stuckReconcilerPositions[consumed.ReconcilerID]; stuck {
-			stepResult.StalenessInfo = e.computeStalenessInfo(stateView, consumed.ReconcilerID, stuckSeqs)
+	if consumed != nil {
+		if staleSeqs := stateView.evaluateStalenessIntervals(consumed.ReconcilerID); len(staleSeqs) > 0 {
+			stepResult.StalenessInfo = e.computeStalenessInfo(stateView, consumed.ReconcilerID, staleSeqs)
+		} else if stateView.stuckReconcilerPositions != nil {
+			if stuckSeqs, stuck := stateView.stuckReconcilerPositions[consumed.ReconcilerID]; stuck {
+				stepResult.StalenessInfo = e.computeStalenessInfo(stateView, consumed.ReconcilerID, stuckSeqs)
+			}
 		}
 	}
 
@@ -1403,6 +1429,7 @@ func (e *Explorer) materializeNextState(
 		action:                   stepResult,
 		divergenceKey:            stateView.divergenceKey,
 		stuckReconcilerPositions: maps.Clone(stateView.stuckReconcilerPositions),
+		stalenessIntervals:       stateView.stalenessIntervals, // immutable config, share reference
 		ExecutionHistory:         append(slices.Clone(stateView.ExecutionHistory), stepResult),
 		nextUserActionIdx:        nextUserActionIdx,
 	}
@@ -1914,6 +1941,12 @@ func (e *Explorer) getTriggeredReconcilers(changes Changes) []PendingReconcile {
 }
 
 func (e *Explorer) getPossibleViewsForReconcile(currState StateNode, reconcilerID ReconcilerID, currDepth int) ([]StateNode, error) {
+	// When interval-based staleness is configured, staleness is deterministic
+	// (handled transparently by ObserveAs) — no branching needed.
+	if len(e.Config.Perturbations.StalenessIntervals) > 0 {
+		return []StateNode{currState}, nil
+	}
+
 	currSnapshot := currState.Contents
 	config, ok := e.Config.Perturbations.Staleness[reconcilerID]
 	if !ok {
@@ -2067,10 +2100,28 @@ func (e *Explorer) determineNewPendingReconciles(ctx context.Context, state Stat
 		).V(1).Info("reconcilers triggered by changes")
 	}
 
-	// for those that would have been triggered but have been configured as "stuck",
-	// filter them out of the triggered list if the changes are contained within the
-	// kinds their watch streams are "stuck" on.
-	if state.stuckReconcilerPositions != nil {
+	// For interval-based staleness: filter out triggers for kinds the reconciler
+	// is currently stale on (its informer hasn't seen those changes yet).
+	if len(state.stalenessIntervals) > 0 {
+		filtered := lo.Filter(triggeredByChanges, func(pending PendingReconcile, _ int) bool {
+			staleSeqs := state.evaluateStalenessIntervals(pending.ReconcilerID)
+			if len(staleSeqs) == 0 {
+				return true // not in any stale window
+			}
+			resourceDeps, _ := e.triggerManager.KindDepsForReconciler(pending.ReconcilerID)
+			for changeKey := range result.Changes.ObjectVersions {
+				canonicalKind := util.CanonicalGroupKind(changeKey.ResourceKey.Group, changeKey.ResourceKey.Kind)
+				if _, staleOnKind := staleSeqs[canonicalKind]; !staleOnKind {
+					if slices.Contains(resourceDeps, canonicalKind) {
+						return true
+					}
+				}
+			}
+			return false
+		})
+		triggeredByChanges = filtered
+	} else if state.stuckReconcilerPositions != nil {
+		// Legacy stuck-reconciler filtering for non-interval staleness.
 		filtered := lo.Filter(triggeredByChanges, func(pending PendingReconcile, _ int) bool {
 			stuckKinds, stuck := state.stuckReconcilerPositions[pending.ReconcilerID]
 			if !stuck {

--- a/pkg/tracecheck/explore.go
+++ b/pkg/tracecheck/explore.go
@@ -1745,15 +1745,21 @@ func (e *Explorer) takeReconcileStep(ctx context.Context, state StateNode, pr Pe
 		return tolerableErrResult, nil
 	}
 	if err != nil {
-		// Other errors cause the branch to be abandoned. Return a minimal result for history tracking.
-		stepLog.WithValues("ReconcilerID", pr.ReconcilerID).Error(err, "error reconciling")
-		failure := &ReconcileResult{
+		// Reconciler errors in real Kubernetes cause a requeue with backoff -- the
+		// reconciler will retry once other controllers advance the state. Treat
+		// the error as a no-op (no state change) and re-enqueue the reconciler so
+		// exploration continues through other pending reconciles.
+		stepLog.WithValues("ReconcilerID", pr.ReconcilerID, "Request", pr.Request).
+			Info("tolerating reconcile error; treating as no-op with re-enqueue")
+		tolerableErrResult := &ReconcileResult{
 			ControllerID: pr.ReconcilerID,
 			FrameID:      frameID,
 			FrameType:    FrameTypeExplore,
+			Changes:      Changes{ObjectVersions: make(ObjectVersions)},
 			Error:        err.Error(),
+			ReenqueueRequest: &pr,
 		}
-		return failure, err
+		return tolerableErrResult, nil
 	}
 
 	return reconcileResult, nil
@@ -2102,6 +2108,17 @@ func (e *Explorer) determineNewPendingReconciles(ctx context.Context, state Stat
 			Request:      consumed.Request,
 			Source:       source,
 			ReadyAtDepth: readyAtDepth,
+		}
+		triggeredByChanges = append(triggeredByChanges, requeued)
+	}
+
+	// If the reconciler errored and requested re-enqueue, add it back so it can
+	// retry after other controllers have had a chance to advance the state.
+	if result.ReenqueueRequest != nil {
+		requeued := PendingReconcile{
+			ReconcilerID: result.ReenqueueRequest.ReconcilerID,
+			Request:      result.ReenqueueRequest.Request,
+			Source:       SourceRequeue,
 		}
 		triggeredByChanges = append(triggeredByChanges, requeued)
 	}

--- a/pkg/tracecheck/staleness_interval_test.go
+++ b/pkg/tracecheck/staleness_interval_test.go
@@ -1,0 +1,205 @@
+package tracecheck
+
+import (
+	"testing"
+)
+
+func TestEvaluateStalenessIntervals_BeforeWindow(t *testing.T) {
+	sn := StateNode{
+		Contents: StateSnapshot{
+			KindSequences: KindSequences{
+				"example.org/Widget": 2, // before StaleAt=3
+			},
+		},
+		stalenessIntervals: []StalenessInterval{
+			{
+				ReconcilerID: "WidgetReconciler",
+				Kind:         "example.org/Widget",
+				StaleAt:      3,
+				CatchUpAt:    7,
+				Lag:          -1,
+			},
+		},
+	}
+
+	result := sn.evaluateStalenessIntervals("WidgetReconciler")
+	if len(result) != 0 {
+		t.Fatalf("expected no stale sequences before window, got %v", result)
+	}
+}
+
+func TestEvaluateStalenessIntervals_DuringWindowFrozen(t *testing.T) {
+	sn := StateNode{
+		Contents: StateSnapshot{
+			KindSequences: KindSequences{
+				"example.org/Widget": 5, // in [3, 7)
+			},
+		},
+		stalenessIntervals: []StalenessInterval{
+			{
+				ReconcilerID: "WidgetReconciler",
+				Kind:         "example.org/Widget",
+				StaleAt:      3,
+				CatchUpAt:    7,
+				Lag:          -1,
+			},
+		},
+	}
+
+	result := sn.evaluateStalenessIntervals("WidgetReconciler")
+	if len(result) != 1 {
+		t.Fatalf("expected 1 stale sequence, got %d", len(result))
+	}
+	if result["example.org/Widget"] != 3 {
+		t.Fatalf("expected frozen at StaleAt=3, got %d", result["example.org/Widget"])
+	}
+}
+
+func TestEvaluateStalenessIntervals_DuringWindowLag(t *testing.T) {
+	sn := StateNode{
+		Contents: StateSnapshot{
+			KindSequences: KindSequences{
+				"example.org/Widget": 5, // in [3, 7), lag=2 → observe at 3
+			},
+		},
+		stalenessIntervals: []StalenessInterval{
+			{
+				ReconcilerID: "WidgetReconciler",
+				Kind:         "example.org/Widget",
+				StaleAt:      3,
+				CatchUpAt:    7,
+				Lag:          2,
+			},
+		},
+	}
+
+	result := sn.evaluateStalenessIntervals("WidgetReconciler")
+	if len(result) != 1 {
+		t.Fatalf("expected 1 stale sequence, got %d", len(result))
+	}
+	if result["example.org/Widget"] != 3 {
+		t.Fatalf("expected lag to clamp at StaleAt=3, got %d", result["example.org/Widget"])
+	}
+}
+
+func TestEvaluateStalenessIntervals_DuringWindowLagNoClamp(t *testing.T) {
+	sn := StateNode{
+		Contents: StateSnapshot{
+			KindSequences: KindSequences{
+				"example.org/Widget": 6, // in [3, 7), lag=1 → observe at 5
+			},
+		},
+		stalenessIntervals: []StalenessInterval{
+			{
+				ReconcilerID: "WidgetReconciler",
+				Kind:         "example.org/Widget",
+				StaleAt:      3,
+				CatchUpAt:    7,
+				Lag:          1,
+			},
+		},
+	}
+
+	result := sn.evaluateStalenessIntervals("WidgetReconciler")
+	if len(result) != 1 {
+		t.Fatalf("expected 1 stale sequence, got %d", len(result))
+	}
+	if result["example.org/Widget"] != 5 {
+		t.Fatalf("expected frontier(6) - lag(1) = 5, got %d", result["example.org/Widget"])
+	}
+}
+
+func TestEvaluateStalenessIntervals_AfterWindow(t *testing.T) {
+	sn := StateNode{
+		Contents: StateSnapshot{
+			KindSequences: KindSequences{
+				"example.org/Widget": 7, // at CatchUpAt, should be current
+			},
+		},
+		stalenessIntervals: []StalenessInterval{
+			{
+				ReconcilerID: "WidgetReconciler",
+				Kind:         "example.org/Widget",
+				StaleAt:      3,
+				CatchUpAt:    7,
+				Lag:          -1,
+			},
+		},
+	}
+
+	result := sn.evaluateStalenessIntervals("WidgetReconciler")
+	if len(result) != 0 {
+		t.Fatalf("expected no stale sequences after window, got %v", result)
+	}
+}
+
+func TestEvaluateStalenessIntervals_DifferentReconciler(t *testing.T) {
+	sn := StateNode{
+		Contents: StateSnapshot{
+			KindSequences: KindSequences{
+				"example.org/Widget": 5, // in window for WidgetReconciler
+			},
+		},
+		stalenessIntervals: []StalenessInterval{
+			{
+				ReconcilerID: "WidgetReconciler",
+				Kind:         "example.org/Widget",
+				StaleAt:      3,
+				CatchUpAt:    7,
+				Lag:          -1,
+			},
+		},
+	}
+
+	result := sn.evaluateStalenessIntervals("OtherReconciler")
+	if len(result) != 0 {
+		t.Fatalf("expected no stale sequences for different reconciler, got %v", result)
+	}
+}
+
+func TestEvaluateStalenessIntervals_NoIntervals(t *testing.T) {
+	sn := StateNode{
+		Contents: StateSnapshot{
+			KindSequences: KindSequences{
+				"example.org/Widget": 5,
+			},
+		},
+	}
+
+	result := sn.evaluateStalenessIntervals("WidgetReconciler")
+	if result != nil {
+		t.Fatalf("expected nil for no intervals, got %v", result)
+	}
+}
+
+func TestObserveAs_WithStalenessIntervals(t *testing.T) {
+	// When stalenessIntervals are configured, ObserveAs should use interval
+	// evaluation and ignore stuckReconcilerPositions.
+	sn := StateNode{
+		Contents: StateSnapshot{
+			KindSequences: KindSequences{
+				"example.org/Widget": 5,
+			},
+		},
+		stalenessIntervals: []StalenessInterval{
+			{
+				ReconcilerID: "WidgetReconciler",
+				Kind:         "example.org/Widget",
+				StaleAt:      3,
+				CatchUpAt:    7,
+				Lag:          -1,
+			},
+		},
+		// stuckReconcilerPositions should be ignored when intervals are set
+		stuckReconcilerPositions: map[ReconcilerID]KindSequences{
+			"WidgetReconciler": {"example.org/Widget": 1},
+		},
+	}
+
+	// For a reconciler not in any interval, should get all objects
+	allObjs := sn.ObserveAs("OtherReconciler")
+	currentObjs := sn.Contents.All()
+	if len(allObjs) != len(currentObjs) {
+		t.Fatalf("expected ObserveAs for non-stale reconciler to return all objects")
+	}
+}

--- a/pkg/tracecheck/start_state.go
+++ b/pkg/tracecheck/start_state.go
@@ -9,6 +9,8 @@ import (
 	"github.com/tgoodwin/kamera/pkg/tag"
 	"github.com/tgoodwin/kamera/pkg/util"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -23,13 +25,21 @@ func buildStartStateFromObjects(store *snapshot.Store, scheme *runtime.Scheme, o
 	kindSeq := make(KindSequences)
 	stateEvents := make([]StateEvent, 0, len(objs))
 
-	// Use a deterministic starting timestamp and increment so sequences are strictly increasing.
-	now := time.Now()
+	// First pass: assign deterministic UIDs to all objects.
 	for idx, obj := range objs {
 		if obj == nil {
 			return StateNode{}, fmt.Errorf("object %d is nil", idx)
 		}
 		tag.EnsureDeterministicIdentity(obj)
+	}
+	// Second pass: fix up ownerReference UIDs to match the deterministic UIDs
+	// assigned in the first pass. Workflow JSONs often specify ownerReferences
+	// with empty UIDs since the real UID isn't known at authoring time.
+	fixupOwnerReferenceUIDs(objs)
+
+	// Use a deterministic starting timestamp and increment so sequences are strictly increasing.
+	now := time.Now()
+	for idx, obj := range objs {
 
 		gvk := ensureObjectGVK(obj, scheme)
 		u, err := util.ConvertToUnstructured(obj)
@@ -60,4 +70,40 @@ func buildStartStateFromObjects(store *snapshot.Store, scheme *runtime.Scheme, o
 		Contents:          snapshot,
 		PendingReconciles: pending,
 	}, nil
+}
+
+// fixupOwnerReferenceUIDs patches ownerReference UIDs on objects whose owners
+// are in the same set. After deterministic UIDs are assigned, any ownerReference
+// with an empty or mismatched UID is corrected to point to the owner's actual UID.
+func fixupOwnerReferenceUIDs(objs []client.Object) {
+	// Build an index: (apiVersion, kind, name) -> UID
+	type ownerKey struct {
+		apiVersion string
+		kind       string
+		name       string
+	}
+	uidIndex := make(map[ownerKey]types.UID, len(objs))
+	for _, obj := range objs {
+		gvk := util.GetGroupVersionKind(obj)
+		av := schema.GroupVersion{Group: gvk.Group, Version: gvk.Version}.String()
+		uidIndex[ownerKey{apiVersion: av, kind: gvk.Kind, name: obj.GetName()}] = obj.GetUID()
+	}
+
+	for _, obj := range objs {
+		refs := obj.GetOwnerReferences()
+		if len(refs) == 0 {
+			continue
+		}
+		changed := false
+		for i, ref := range refs {
+			key := ownerKey{apiVersion: ref.APIVersion, kind: ref.Kind, name: ref.Name}
+			if ownerUID, ok := uidIndex[key]; ok && ref.UID != ownerUID {
+				refs[i].UID = ownerUID
+				changed = true
+			}
+		}
+		if changed {
+			obj.SetOwnerReferences(refs)
+		}
+	}
 }

--- a/pkg/tracecheck/state.go
+++ b/pkg/tracecheck/state.go
@@ -271,9 +271,26 @@ type StateNode struct {
 	// tracks what KindSequences a controller may be "stuck" on
 	// e.g. if a controller's watches are connected to a partitioned APIServer
 	stuckReconcilerPositions map[ReconcilerID]KindSequences
+
+	// stalenessIntervals carries immutable interval config from ExploreConfig.
+	// When non-nil, ObserveAs uses interval evaluation instead of stuckReconcilerPositions.
+	stalenessIntervals []StalenessInterval
 }
 
 func (sn StateNode) ObserveAs(reconcilerID ReconcilerID) ObjectVersions {
+	// Interval-based staleness takes precedence when configured.
+	if len(sn.stalenessIntervals) > 0 {
+		staleSeqs := sn.evaluateStalenessIntervals(reconcilerID)
+		if len(staleSeqs) == 0 {
+			return sn.Contents.All()
+		}
+		kindSequences := maps.Clone(sn.Contents.KindSequences)
+		for k, seq := range staleSeqs {
+			kindSequences[k] = seq
+		}
+		return sn.Contents.ObserveAt(kindSequences)
+	}
+
 	if sn.stuckReconcilerPositions == nil {
 		return sn.Contents.All()
 	}
@@ -286,6 +303,37 @@ func (sn StateNode) ObserveAs(reconcilerID ReconcilerID) ObjectVersions {
 		return sn.Contents.ObserveAt(kindSequences)
 	}
 	return sn.Contents.All()
+}
+
+// evaluateStalenessIntervals returns stale KindSequences for the given reconciler
+// based on configured staleness intervals and the current frontier sequences.
+func (sn StateNode) evaluateStalenessIntervals(reconcilerID ReconcilerID) KindSequences {
+	if len(sn.stalenessIntervals) == 0 {
+		return nil
+	}
+	var result KindSequences
+	for _, interval := range sn.stalenessIntervals {
+		if interval.ReconcilerID != reconcilerID {
+			continue
+		}
+		frontier := sn.Contents.KindSequences[interval.Kind]
+		if frontier < interval.StaleAt || frontier >= interval.CatchUpAt {
+			continue // not in stale window
+		}
+		if result == nil {
+			result = make(KindSequences)
+		}
+		if interval.Lag == -1 {
+			result[interval.Kind] = interval.StaleAt
+		} else {
+			staleSeq := frontier - interval.Lag
+			if staleSeq < interval.StaleAt {
+				staleSeq = interval.StaleAt
+			}
+			result[interval.Kind] = staleSeq
+		}
+	}
+	return result
 }
 
 func (sn StateNode) DumpPending() {
@@ -367,6 +415,7 @@ func (sn StateNode) Clone() StateNode {
 		divergenceKey:     sn.divergenceKey,
 
 		stuckReconcilerPositions: maps.Clone(sn.stuckReconcilerPositions),
+		stalenessIntervals:       sn.stalenessIntervals, // immutable config, share reference
 	}
 }
 

--- a/pkg/tracecheck/state.go
+++ b/pkg/tracecheck/state.go
@@ -102,6 +102,12 @@ type ReconcileResult struct {
 	// Only populated when the controller observed a stale view.
 	StalenessInfo []StaleReadInfo `json:"stalenessInfo,omitempty"`
 
+	// ReenqueueRequest, when non-nil, causes the reconciler to be re-enqueued
+	// after the step completes. Used to model controller-runtime's error-driven
+	// requeue behavior: the reconciler errored, but exploration should continue
+	// through other pending reconciles before retrying.
+	ReenqueueRequest *PendingReconcile `json:"-"`
+
 	ctrlRes reconcile.Result
 }
 


### PR DESCRIPTION
## Summary
- Implement interval-based staleness model with reconciliation intervals
- Add integration test inputs for the new staleness model
- Add comprehensive integration tests for interval-based staleness

## Test Plan
- [x] All existing tests pass
- [x] New integration tests pass (pkg/test/integration/staleness_interval_test.go)