### PR TITLE
knative-serving: disable WatchListClient feature gate in fake informers

### DIFF
--- a/examples/knative-serving/knative/fake_informers.go
+++ b/examples/knative-serving/knative/fake_informers.go
@@ -5,7 +5,7 @@ package kamera
 // whenever the kamera package is imported, so callers don't need to remember to
 // add these everywhere.
 import (
-	clientgofeatures "k8s.io/client-go/features"
+	"k8s.io/client-go/features"
 	_ "knative.dev/caching/pkg/client/injection/informers/caching/v1alpha1/image/fake"
 	_ "knative.dev/networking/pkg/client/injection/informers/networking/v1alpha1/certificate/fake"
 	_ "knative.dev/networking/pkg/client/injection/informers/networking/v1alpha1/ingress/fake"
@@ -31,10 +31,10 @@ import (
 
 func init() {
 	type featureSetter interface {
-		clientgofeatures.Gates
-		Set(clientgofeatures.Feature, bool) error
+		features.Gates
+		Set(features.Feature, bool) error
 	}
-	if fs, ok := clientgofeatures.FeatureGates().(featureSetter); ok {
-		_ = fs.Set(clientgofeatures.WatchListClient, false)
+	if fs, ok := features.FeatureGates().(featureSetter); ok {
+		_ = fs.Set(features.WatchListClient, false)
 	}
 }

--- a/examples/knative-serving/knative/fake_informers.go
+++ b/examples/knative-serving/knative/fake_informers.go
@@ -5,6 +5,7 @@ package kamera
 // whenever the kamera package is imported, so callers don't need to remember to
 // add these everywhere.
 import (
+	clientgofeatures "k8s.io/client-go/features"
 	_ "knative.dev/caching/pkg/client/injection/informers/caching/v1alpha1/image/fake"
 	_ "knative.dev/networking/pkg/client/injection/informers/networking/v1alpha1/certificate/fake"
 	_ "knative.dev/networking/pkg/client/injection/informers/networking/v1alpha1/ingress/fake"
@@ -27,3 +28,13 @@ import (
 	_ "knative.dev/serving/pkg/client/injection/informers/serving/v1/route/fake"
 	_ "knative.dev/serving/pkg/client/injection/informers/serving/v1/service/fake"
 )
+
+func init() {
+	type featureSetter interface {
+		clientgofeatures.Gates
+		Set(clientgofeatures.Feature, bool) error
+	}
+	if fs, ok := clientgofeatures.FeatureGates().(featureSetter); ok {
+		_ = fs.Set(clientgofeatures.WatchListClient, false)
+	}
+}


### PR DESCRIPTION
`k8s.io/client-go` v0.35.0 graduates `WatchListClient` to Beta-enabled-by-default (off through v1.34). When enabled, reflectors issue a `WATCHLIST` request and wait for a bookmark event to signal the initial sync is complete. Fake API servers used in tests don't emit bookmark events, so the reflector logs:

```
Warning: event bookmark expired ... awaiting required bookmark event for initial events stream, no events received for 5m10s
```

…and blocks indefinitely. Disabling the gate reverts to the standard `LIST`+`WATCH` flow, which fake clients handle correctly.