### PR TITLE
fix resourceVersion fidelity gaps

### DIFF
--- a/pkg/tracecheck/explore.go
+++ b/pkg/tracecheck/explore.go
@@ -44,12 +44,12 @@ type EffectContextManager interface {
 // StalenessInterval defines a window during which a reconciler's view
 // of a specific resource kind lags behind the actual cluster state.
 type StalenessInterval struct {
-	ReconcilerID    ReconcilerID `json:"reconciler"`
-	Kind            string       `json:"kind"`  // canonical group/kind
-	StaleAt         int64        `json:"staleAt"`
-	CatchUpAt       int64        `json:"catchUpAt"`
-	Lag             int64        `json:"lag"`             // how far behind frontier; -1 = frozen
-	FreezeAtSequence int64       `json:"freezeAt,omitempty"` // when lag=-1 and set, freeze at this sequence instead of staleAt
+	ReconcilerID     ReconcilerID `json:"reconciler"`
+	Kind             string       `json:"kind"` // canonical group/kind
+	StaleAt          int64        `json:"staleAt"`
+	CatchUpAt        int64        `json:"catchUpAt"`
+	Lag              int64        `json:"lag"`                // how far behind frontier; -1 = frozen
+	FreezeAtSequence int64        `json:"freezeAt,omitempty"` // when lag=-1 and set, freeze at this sequence instead of staleAt
 }
 
 // PermuteDepthRange constrains ordering permutations to a specific depth window.
@@ -1666,7 +1666,10 @@ func (e *Explorer) emitAbortedState(
 }
 
 func (e *Explorer) applyEffects(stepLogger logr.Logger, stateView StateNode, stepResult *ReconcileResult) (ObjectVersions, KindSequences, []StateEvent) {
-	changes := stepResult.Changes.ObjectVersions
+	// Materialize each effect from its own version. ObjectVersions is a final
+	// writeset and therefore cannot represent multiple writes to the same key.
+	changes := make(ObjectVersions, len(stepResult.Changes.ObjectVersions))
+	stepResult.Changes.ObjectVersions = changes
 
 	// initialize outputs which the effects will be applied to
 	nextState := maps.Clone(stateView.Objects())
@@ -1681,6 +1684,11 @@ func (e *Explorer) applyEffects(stepLogger logr.Logger, stateView StateNode, ste
 
 	for _, effect := range stepResult.Changes.Effects {
 		existingKey, exists := nextState.HasNamespacedNameForKind(effect.Key.ResourceKey)
+		currentVersion := snapshot.VersionHash{}
+		if exists {
+			currentVersion = nextState[existingKey]
+		}
+		appliedVersion, noOp := resolveEffectVersion(e.versionManager, currentVersion, exists, effect)
 
 		switch effect.OpType {
 		case event.CREATE:
@@ -1696,10 +1704,10 @@ func (e *Explorer) applyEffects(stepLogger logr.Logger, stateView StateNode, ste
 				if gen == 0 {
 					newObj.SetGeneration(1)
 					// Update the version hash after modifying Generation
-					changes[effect.Key] = e.versionManager.Publish(newObj)
+					appliedVersion = e.versionManager.Publish(newObj)
 				}
 			}
-			nextState[effect.Key] = changes[effect.Key]
+			nextState[effect.Key] = appliedVersion
 		case event.UPDATE, event.PATCH:
 			if !exists {
 				// it is possible that a stale read will cause a controller to update an object
@@ -1709,30 +1717,19 @@ func (e *Explorer) applyEffects(stepLogger logr.Logger, stateView StateNode, ste
 				panic("update effect object not found in prev state: " + effect.Key.String())
 			}
 			oldVersion := nextState[existingKey]
+			if noOp {
+				continue
+			}
 			if exists && existingKey != effect.Key {
 				delete(nextState, existingKey)
 			}
 			if effect.Subresource == "status" {
-				oldObj := e.versionManager.Resolve(oldVersion)
-				newObj := e.versionManager.Resolve(effect.Version)
-				mergedObj := mergeStatusSubresourceObject(oldObj, newObj, effect.OpType == event.PATCH || effect.OpType == event.APPLY)
-				mergedHash := e.versionManager.Publish(mergedObj)
-				// No-op: if merged result is identical to current state, skip.
-				// Real K8s API server detects identical status patches and
-				// skips the etcd write — no resourceVersion bump, no watch event.
-				if mergedHash == oldVersion {
-					continue
-				}
-				changes[effect.Key] = mergedHash
-				nextState[effect.Key] = changes[effect.Key]
+				nextState[effect.Key] = appliedVersion
 				break
 			}
 			// No-op detection: if the effect produces the same content hash as
 			// what's already in state, skip it. This matches real API server
 			// behavior where a PATCH that doesn't change anything is a no-op.
-			if effect.Version == oldVersion {
-				continue
-			}
 			// Mimic APIServer behavior: increment Generation on spec updates (not status-only updates)
 			oldObj := e.versionManager.Resolve(oldVersion)
 			newObj := e.versionManager.Resolve(effect.Version)
@@ -1759,26 +1756,24 @@ func (e *Explorer) applyEffects(stepLogger logr.Logger, stateView StateNode, ste
 						stepLogger.V(2).WithValues("key", effect.Key, "oldGen", oldGen, "newGen", newObj.GetGeneration()).Info("incremented Generation on spec update")
 					}
 					// Update the version hash after modifying Generation
-					changes[effect.Key] = e.versionManager.Publish(newObj)
+					appliedVersion = e.versionManager.Publish(newObj)
 				}
 			}
-			nextState[effect.Key] = changes[effect.Key]
+			nextState[effect.Key] = appliedVersion
 		case event.APPLY:
 			if effect.Subresource == "status" {
 				if !exists {
 					panic("status apply effect object not found in prev state: " + effect.Key.String())
 				}
 
-				oldVersion := nextState[existingKey]
+				if noOp {
+					continue
+				}
 				if exists && existingKey != effect.Key {
 					delete(nextState, existingKey)
 				}
 
-				oldObj := e.versionManager.Resolve(oldVersion)
-				newObj := e.versionManager.Resolve(effect.Version)
-				mergedObj := mergeStatusSubresourceObject(oldObj, newObj, effect.OpType == event.PATCH || effect.OpType == event.APPLY)
-				changes[effect.Key] = e.versionManager.Publish(mergedObj)
-				nextState[effect.Key] = changes[effect.Key]
+				nextState[effect.Key] = appliedVersion
 				break
 			}
 
@@ -1791,10 +1786,10 @@ func (e *Explorer) applyEffects(stepLogger logr.Logger, stateView StateNode, ste
 					if gen == 0 {
 						newObj.SetGeneration(1)
 						// Update the version hash after modifying Generation
-						changes[effect.Key] = e.versionManager.Publish(newObj)
+						appliedVersion = e.versionManager.Publish(newObj)
 					}
 				}
-				nextState[effect.Key] = changes[effect.Key]
+				nextState[effect.Key] = appliedVersion
 				break
 			}
 
@@ -1807,17 +1802,9 @@ func (e *Explorer) applyEffects(stepLogger logr.Logger, stateView StateNode, ste
 			oldVersion := nextState[existingKey]
 			oldObj := e.versionManager.Resolve(oldVersion)
 			newObj := e.versionManager.Resolve(effect.Version)
-			if oldObj != nil && newObj != nil {
-				// Real K8s API server (v1.21+) detects SSA no-op applies and
-				// skips the etcd write entirely — no resourceVersion bump, no
-				// watch event. Compare the full object content (not just spec)
-				// to match this behavior.
-				specChanged, _ := snapshot.CheckSpecChanged(oldObj, newObj)
-				metadataChanged := !metadataEqual(oldObj, newObj)
-				if !specChanged && !metadataChanged {
-					stepLogger.V(2).WithValues("key", effect.Key).Info("no-op SSA Apply: content unchanged, skipping effect")
-					continue
-				}
+			if noOp {
+				stepLogger.V(2).WithValues("key", effect.Key).Info("no-op SSA Apply: content unchanged, skipping effect")
+				continue
 			}
 
 			// Capture the existing version before any key replacement.
@@ -1851,10 +1838,10 @@ func (e *Explorer) applyEffects(stepLogger logr.Logger, stateView StateNode, ste
 						stepLogger.V(2).WithValues("key", effect.Key, "oldGen", oldGen, "newGen", newObj.GetGeneration()).Info("incremented Generation on spec update")
 					}
 					// Update the version hash after modifying Generation
-					changes[effect.Key] = e.versionManager.Publish(newObj)
+					appliedVersion = e.versionManager.Publish(newObj)
 				}
 			}
-			nextState[effect.Key] = changes[effect.Key]
+			nextState[effect.Key] = appliedVersion
 
 		// need to determine how to update state based on preconditions
 		case event.MARK_FOR_DELETION:
@@ -1869,7 +1856,7 @@ func (e *Explorer) applyEffects(stepLogger logr.Logger, stateView StateNode, ste
 				delete(nextState, existingKey)
 			}
 			// the delete effect is valid, so we should add it to the state
-			nextState[effect.Key] = changes[effect.Key]
+			nextState[effect.Key] = appliedVersion
 
 		case event.REMOVE:
 			if !exists {
@@ -1883,23 +1870,32 @@ func (e *Explorer) applyEffects(stepLogger logr.Logger, stateView StateNode, ste
 			panic(fmt.Errorf("unknown effect type: %s", effect.OpType))
 		}
 
-		highestSequence++
-		newRV := highestSequence
+		changes[effect.Key] = appliedVersion
+
+		newRV := highestSequence + 1
+		if effect.ResourceVersion != 0 {
+			if effect.ResourceVersion != newRV {
+				panic(fmt.Sprintf("effect resourceVersion %d does not follow branch sequence %d", effect.ResourceVersion, highestSequence))
+			}
+			newRV = effect.ResourceVersion
+		}
+		highestSequence = newRV
 
 		// increment resourceversion for the kind
 		nextSequences[effect.Key.IdentityKey.CanonicalGroupKind()] = newRV
 
 		// Record the global ResourceVersion for this object version so that
 		// staleness analysis can compare observed vs current RV.
-		if vHash := changes[effect.Key]; vHash.Value != "" && e.resourceVersions != nil {
-			e.resourceVersions[vHash] = newRV
+		if appliedVersion.Value != "" && e.resourceVersions != nil {
+			e.resourceVersions[appliedVersion] = newRV
 		}
 
 		// Use the post-modification version hash (after Generation bumps, etc.)
 		// rather than the original effect's version, so that stateEvent hashes
 		// stay consistent with Contents.contents for staleness replay.
 		recordedEffect := effect
-		recordedEffect.Version = changes[effect.Key]
+		recordedEffect.Version = appliedVersion
+		recordedEffect.ResourceVersion = newRV
 		stateEvent := StateEvent{
 			ReconcileID: stepResult.FrameID,
 			Sequence:    newRV,
@@ -1989,6 +1985,7 @@ func (e *Explorer) takeReconcileStep(ctx context.Context, state StateNode, pr Pe
 	// create a new frameID for this reconcile state transition
 	frameID := util.UUID()
 	ctx = replay.WithFrameID(ctx, frameID)
+	ctx = withResourceVersionBase(ctx, state.Contents.highestSequence())
 
 	// increment simulated time by setting the simulated clock depth to match the depth of this state
 	// Tickers that fire during SetDepth will add enqueues to the global collector.
@@ -2025,11 +2022,11 @@ func (e *Explorer) takeReconcileStep(ctx context.Context, state StateNode, pr Pe
 		// reconcileResult is nil — the error occurred before any effects
 		// could be recorded (e.g., state preparation failure). Treat as no-op.
 		tolerableErrResult := &ReconcileResult{
-			ControllerID: pr.ReconcilerID,
-			FrameID:      frameID,
-			FrameType:    FrameTypeExplore,
-			Changes:      Changes{ObjectVersions: make(ObjectVersions)},
-			Error:        err.Error(),
+			ControllerID:     pr.ReconcilerID,
+			FrameID:          frameID,
+			FrameType:        FrameTypeExplore,
+			Changes:          Changes{ObjectVersions: make(ObjectVersions)},
+			Error:            err.Error(),
 			ReenqueueRequest: &pr,
 		}
 		return tolerableErrResult, nil
@@ -2058,6 +2055,7 @@ func (e *Explorer) takeUserActionStep(ctx context.Context, state StateNode) (*Re
 
 	stepLog.WithValues("ActionIdx", state.nextUserActionIdx).V(2).Info("about to execute user action")
 
+	ctx = withResourceVersionBase(ctx, state.Contents.highestSequence())
 	result, err := e.userController.ExecuteNextAction(ctx, state.Objects(), state.nextUserActionIdx)
 	if err != nil {
 		if result == nil {

--- a/pkg/tracecheck/explore_apply_test.go
+++ b/pkg/tracecheck/explore_apply_test.go
@@ -688,3 +688,59 @@ func TestApplyEffects_StateEventHashMatchesContents_MultipleEffects(t *testing.T
 			"resourceVersion must match stateEvent sequence for key %s", se.Effect.Key)
 	}
 }
+
+func TestApplyEffects_PreservesMultipleWritesToSameObject(t *testing.T) {
+	store := snapshot.NewStore()
+	vs := NewVersionStore(store, nil)
+	explorer := &Explorer{
+		versionManager:   vs,
+		resourceVersions: make(map[snapshot.VersionHash]int64),
+	}
+
+	key := snapshot.NewCompositeKeyWithGroup("", "ConfigMap", "default", "example", "obj1")
+	oldObj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata": map[string]any{
+			"namespace": "default",
+			"name":      "example",
+		},
+		"data": map[string]any{"step": "0"},
+	}}
+	firstObj := oldObj.DeepCopy()
+	firstObj.Object["data"] = map[string]any{"step": "1"}
+	secondObj := oldObj.DeepCopy()
+	secondObj.Object["data"] = map[string]any{"step": "2"}
+
+	oldHash := vs.Publish(oldObj)
+	firstHash := vs.Publish(firstObj)
+	secondHash := vs.Publish(secondObj)
+	explorer.resourceVersions[oldHash] = 5
+
+	initialEvent := StateEvent{Sequence: 5, Effect: Effect{OpType: event.CREATE, Key: key, Version: oldHash, ResourceVersion: 5}}
+	state := StateNode{Contents: NewStateSnapshot(
+		ObjectVersions{key: oldHash},
+		KindSequences{key.CanonicalGroupKind(): 5},
+		[]StateEvent{initialEvent},
+	)}
+	stepResult := &ReconcileResult{
+		FrameID: "frame-two-writes",
+		Changes: Changes{
+			ObjectVersions: ObjectVersions{key: secondHash},
+			Effects: []Effect{
+				{OpType: event.UPDATE, Key: key, Version: firstHash, ResourceVersion: 6},
+				{OpType: event.UPDATE, Key: key, Version: secondHash, ResourceVersion: 7},
+			},
+		},
+	}
+
+	nextState, _, stateEvents := explorer.applyEffects(logr.Discard(), state, stepResult)
+	require.Len(t, stateEvents, 3)
+	require.Equal(t, int64(6), stateEvents[1].Sequence)
+	require.Equal(t, firstHash, stateEvents[1].Effect.Version)
+	require.Equal(t, int64(7), stateEvents[2].Sequence)
+	require.Equal(t, secondHash, stateEvents[2].Effect.Version)
+	require.Equal(t, secondHash, nextState[key])
+	require.Equal(t, int64(6), explorer.resourceVersions[firstHash])
+	require.Equal(t, int64(7), explorer.resourceVersions[secondHash])
+}

--- a/pkg/tracecheck/explorebuilder.go
+++ b/pkg/tracecheck/explorebuilder.go
@@ -961,7 +961,9 @@ func (b *ExplorerBuilder) Build(modes ...string) (*Explorer, error) {
 
 		// effectRVs tracks the current integer resourceVersion per resource key
 		// per frame, for optimistic concurrency conflict checking.
-		effectRVs: make(map[string]map[string]int64),
+		effectRVs:      make(map[string]map[string]int64),
+		effectVersions: make(map[string]map[string]snapshot.VersionHash),
+		effectNextRVs:  make(map[string]int64),
 	}
 
 	// Initialize reconcilers with appropriate clients
@@ -1031,12 +1033,14 @@ func (b *ExplorerBuilder) BuildLensManager(traceFilePath string) (*LensManager, 
 	}
 	rollup := CausalRollup(traces)
 	mgr := &manager{
-		versionStore: NewVersionStore(b.snapStore, b.scheme),
-		effects:      make(map[string]reconcileEffects),
-		scheme:       b.scheme,
-		effectRKeys:  make(map[string]util.Set[string]),
-		effectIKeys:  make(map[string]util.Set[snapshot.IdentityKey]),
-		effectRVs:    make(map[string]map[string]int64),
+		versionStore:   NewVersionStore(b.snapStore, b.scheme),
+		effects:        make(map[string]reconcileEffects),
+		scheme:         b.scheme,
+		effectRKeys:    make(map[string]util.Set[string]),
+		effectIKeys:    make(map[string]util.Set[snapshot.IdentityKey]),
+		effectRVs:      make(map[string]map[string]int64),
+		effectVersions: make(map[string]map[string]snapshot.VersionHash),
+		effectNextRVs:  make(map[string]int64),
 	}
 
 	return NewLensManager(

--- a/pkg/tracecheck/manager.go
+++ b/pkg/tracecheck/manager.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -98,6 +99,30 @@ func canonicalResourceKeyString(group, kind, namespace, name string) string {
 	return fmt.Sprintf("%s/%s/%s", util.CanonicalGroupKind(group, kind), namespace, name)
 }
 
+func invalidResourceVersion(gvk schema.GroupVersionKind, name string, value any, detail string) error {
+	return apierrors.NewInvalid(
+		schema.GroupKind{Group: gvk.Group, Kind: gvk.Kind},
+		name,
+		field.ErrorList{field.Invalid(field.NewPath("metadata", "resourceVersion"), value, detail)},
+	)
+}
+
+func (m *manager) advanceEffectResourceVersion(frameID, resourceKey string, obj client.Object) {
+	rvs, ok := m.effectRVs[frameID]
+	if !ok {
+		return
+	}
+
+	var nextRV int64 = 1
+	for _, rv := range rvs {
+		if rv >= nextRV {
+			nextRV = rv + 1
+		}
+	}
+	rvs[resourceKey] = nextRV
+	obj.SetResourceVersion(strconv.FormatInt(nextRV, 10))
+}
+
 func (m *manager) Summary() {
 	store := m.versionStore.GetVersionMap(snapshot.AnonymizedHash)
 	for k, v := range store {
@@ -167,12 +192,10 @@ func (m *manager) RecordEffect(ctx context.Context, obj client.Object, opType ev
 		reffects.reads = append(reffects.reads, eff)
 	} else {
 		reffects.writes = append(reffects.writes, eff)
-
-		// Note: we do NOT advance effectRVs here. The tracked RV stays at
-		// the pre-reconcile ground truth value. This means all writes within
-		// a single reconcile are checked against the same baseline. The conflict
-		// only fires when the controller was served a stale cache frame (RV=N)
-		// but the ground truth is already at RV=N+1 from a prior reconcile step.
+		if opType != event.REMOVE {
+			resourceKey := canonicalResourceKeyString(gvk.Group, kind, obj.GetNamespace(), obj.GetName())
+			m.advanceEffectResourceVersion(frameID, resourceKey, obj)
+		}
 	}
 	m.effects[frameID] = reffects
 	logger.V(2).Info("recorded effects", "frameID", frameID, "numReads", len(reffects.reads), "numWrites", len(reffects.writes))
@@ -315,25 +338,29 @@ func (m *manager) validateEffect(ctx context.Context, op event.OperationType, ob
 		var claimedRVStr string
 		if op == event.UPDATE {
 			claimedRVStr = obj.GetResourceVersion()
+			if claimedRVStr == "" {
+				return invalidResourceVersion(gvk, obj.GetName(), claimedRVStr, "must be specified for an update")
+			}
 		} else if precondition != nil && precondition.ResourceVersion != nil {
 			claimedRVStr = *precondition.ResourceVersion
 		}
 		if claimedRVStr != "" {
+			claimedRV, err := strconv.ParseInt(claimedRVStr, 10, 64)
+			if err != nil || claimedRV <= 0 {
+				return invalidResourceVersion(gvk, obj.GetName(), claimedRVStr, "must be a positive integer")
+			}
 			if rvs, ok := m.effectRVs[frameID]; ok {
 				currentRV, tracked := rvs[resourceKey]
-				if tracked {
-					claimedRV, err := strconv.ParseInt(claimedRVStr, 10, 64)
-					if err == nil && claimedRV != currentRV {
-						logger.V(1).Info("resourceVersion conflict",
-							"key", resourceKey,
-							"claimedRV", claimedRV,
-							"currentRV", currentRV)
-						return apierrors.NewConflict(
-							schema.GroupResource{Group: gvk.Group, Resource: gvk.Kind},
-							obj.GetName(),
-							fmt.Errorf("the object has been modified; please apply your changes to the latest version"),
-						)
-					}
+				if tracked && claimedRV != currentRV {
+					logger.V(1).Info("resourceVersion conflict",
+						"key", resourceKey,
+						"claimedRV", claimedRV,
+						"currentRV", currentRV)
+					return apierrors.NewConflict(
+						schema.GroupResource{Group: gvk.Group, Resource: gvk.Kind},
+						obj.GetName(),
+						fmt.Errorf("the object has been modified; please apply your changes to the latest version"),
+					)
 				}
 			}
 		}

--- a/pkg/tracecheck/manager.go
+++ b/pkg/tracecheck/manager.go
@@ -32,10 +32,14 @@ type VersionManager interface {
 }
 
 type Effect struct {
-	OpType      event.OperationType
-	Key         snapshot.CompositeKey
-	Version     snapshot.VersionHash
-	Subresource string `json:"subresource,omitempty"`
+	OpType  event.OperationType
+	Key     snapshot.CompositeKey
+	Version snapshot.VersionHash
+	// ResourceVersion is the API-server sequence assigned when this write was
+	// accepted. A zero value is retained for imported/legacy effects whose
+	// sequence is assigned during materialization.
+	ResourceVersion int64  `json:"resourceVersion,omitempty"`
+	Subresource     string `json:"subresource,omitempty"`
 
 	Precondition *replay.PreconditionInfo
 }
@@ -87,6 +91,12 @@ type manager struct {
 	// within a reconcile frame, used for optimistic concurrency conflict checking.
 	// frameID → resourceKey → current integer RV
 	effectRVs map[string]map[string]int64
+	// effectVersions tracks the latest accepted object version for each resource
+	// within a frame. It lets the simulated write path identify no-op patches
+	// before advancing the optimistic-concurrency baseline.
+	effectVersions map[string]map[string]snapshot.VersionHash
+	// effectNextRVs is the next branch-local global sequence to assign.
+	effectNextRVs map[string]int64
 
 	// rvLookup maps VersionHash → integer resourceVersion.
 	// Set from the explorer's resourceVersions map.
@@ -107,20 +117,59 @@ func invalidResourceVersion(gvk schema.GroupVersionKind, name string, value any,
 	)
 }
 
-func (m *manager) advanceEffectResourceVersion(frameID, resourceKey string, obj client.Object) {
+type resourceVersionBaseContextKey struct{}
+
+func withResourceVersionBase(ctx context.Context, base int64) context.Context {
+	return context.WithValue(ctx, resourceVersionBaseContextKey{}, base)
+}
+
+func resourceVersionBaseFromContext(ctx context.Context) int64 {
+	base, _ := ctx.Value(resourceVersionBaseContextKey{}).(int64)
+	return base
+}
+
+func (m *manager) allocateEffectResourceVersion(frameID string) int64 {
+	nextRV := m.effectNextRVs[frameID]
+	m.effectNextRVs[frameID] = nextRV + 1
+	return nextRV
+}
+
+func (m *manager) advanceEffectResourceVersion(frameID, resourceKey string, obj client.Object) int64 {
 	rvs, ok := m.effectRVs[frameID]
 	if !ok {
-		return
+		return 0
 	}
 
-	var nextRV int64 = 1
-	for _, rv := range rvs {
-		if rv >= nextRV {
-			nextRV = rv + 1
-		}
-	}
+	nextRV := m.allocateEffectResourceVersion(frameID)
 	rvs[resourceKey] = nextRV
 	obj.SetResourceVersion(strconv.FormatInt(nextRV, 10))
+	return nextRV
+}
+
+func resolveEffectVersion(versionManager VersionManager, currentVersion snapshot.VersionHash, exists bool, effect Effect) (snapshot.VersionHash, bool) {
+	if !exists {
+		return effect.Version, false
+	}
+
+	oldObj := versionManager.Resolve(currentVersion)
+	newObj := versionManager.Resolve(effect.Version)
+	if effect.Subresource == "status" && (effect.OpType == event.UPDATE || effect.OpType == event.PATCH || effect.OpType == event.APPLY) {
+		merged := mergeStatusSubresourceObject(oldObj, newObj, effect.OpType == event.PATCH || effect.OpType == event.APPLY)
+		mergedVersion := versionManager.Publish(merged)
+		return mergedVersion, mergedVersion == currentVersion
+	}
+
+	switch effect.OpType {
+	case event.UPDATE, event.PATCH:
+		return effect.Version, effect.Version == currentVersion
+	case event.APPLY:
+		if oldObj != nil && newObj != nil {
+			specChanged, _ := snapshot.CheckSpecChanged(oldObj, newObj)
+			metadataChanged := !metadataEqual(oldObj, newObj)
+			return effect.Version, !specChanged && !metadataChanged
+		}
+	}
+	return effect.Version, false
 }
 
 func (m *manager) Summary() {
@@ -174,6 +223,10 @@ func (m *manager) RecordEffect(ctx context.Context, obj client.Object, opType ev
 	if err != nil {
 		return err
 	}
+	// resourceVersion is API-server metadata, not part of the logical object
+	// version stored in exploration state. Keep it on the caller's object for
+	// OCC and return-value fidelity, but exclude it from content hashing.
+	u.SetResourceVersion("")
 
 	// publish the object versionHash
 	versionHash := m.Publish(u)
@@ -191,11 +244,23 @@ func (m *manager) RecordEffect(ctx context.Context, obj client.Object, opType ev
 	if opType == event.GET || opType == event.LIST {
 		reffects.reads = append(reffects.reads, eff)
 	} else {
-		reffects.writes = append(reffects.writes, eff)
-		if opType != event.REMOVE {
-			resourceKey := canonicalResourceKeyString(gvk.Group, kind, obj.GetNamespace(), obj.GetName())
-			m.advanceEffectResourceVersion(frameID, resourceKey, obj)
+		resourceKey := canonicalResourceKeyString(gvk.Group, kind, obj.GetNamespace(), obj.GetName())
+		currentVersion, exists := m.effectVersions[frameID][resourceKey]
+		materializedVersion, noOp := resolveEffectVersion(m.versionStore, currentVersion, exists, eff)
+		if noOp {
+			logger.V(2).Info("accepted no-op write", "frameID", frameID, "key", resourceKey, "opType", opType)
+			return nil
 		}
+
+		if opType != event.REMOVE {
+			eff.ResourceVersion = m.advanceEffectResourceVersion(frameID, resourceKey, obj)
+			m.effectVersions[frameID][resourceKey] = materializedVersion
+		} else {
+			eff.ResourceVersion = m.allocateEffectResourceVersion(frameID)
+			delete(m.effectVersions[frameID], resourceKey)
+			delete(m.effectRVs[frameID], resourceKey)
+		}
+		reffects.writes = append(reffects.writes, eff)
 	}
 	m.effects[frameID] = reffects
 	logger.V(2).Info("recorded effects", "frameID", frameID, "numReads", len(reffects.reads), "numWrites", len(reffects.writes))
@@ -214,9 +279,11 @@ func (m *manager) PrepareEffectContext(ctx context.Context, ov ObjectVersions) e
 	// holds kind/namespace/name
 	rKeySet := util.NewSet[string]()
 	rvs := make(map[string]int64, len(ov))
+	versions := make(map[string]snapshot.VersionHash, len(ov))
 	for ck, vh := range ov {
 		primary := canonicalResourceKeyString(ck.ResourceKey.Group, ck.ResourceKey.Kind, ck.ResourceKey.Namespace, ck.ResourceKey.Name)
 		rKeySet.Add(primary)
+		versions[primary] = vh
 		// Look up the integer RV for this object version
 		if m.rvLookup != nil {
 			if rv := m.rvLookup(vh); rv > 0 {
@@ -227,6 +294,18 @@ func (m *manager) PrepareEffectContext(ctx context.Context, ov ObjectVersions) e
 	m.effectRKeys[frameID] = rKeySet
 	m.effectIKeys[frameID] = util.NewSet(iKeys...)
 	m.effectRVs[frameID] = rvs
+	m.effectVersions[frameID] = versions
+	baseRV := resourceVersionBaseFromContext(ctx)
+	if baseRV == 0 {
+		// Keep direct manager callers useful while production exploration always
+		// supplies the branch's authoritative state-event frontier.
+		for _, rv := range rvs {
+			if rv > baseRV {
+				baseRV = rv
+			}
+		}
+	}
+	m.effectNextRVs[frameID] = baseRV + 1
 	return nil
 }
 
@@ -235,6 +314,8 @@ func (m *manager) CleanupEffectContext(ctx context.Context) {
 	delete(m.effectRKeys, frameID)
 	delete(m.effectIKeys, frameID)
 	delete(m.effectRVs, frameID)
+	delete(m.effectVersions, frameID)
+	delete(m.effectNextRVs, frameID)
 }
 
 func (m *manager) GetEffects(ctx context.Context) (Changes, error) {

--- a/pkg/tracecheck/manager_rv_test.go
+++ b/pkg/tracecheck/manager_rv_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/tgoodwin/kamera/pkg/event"
 	"github.com/tgoodwin/kamera/pkg/replay"
 	"github.com/tgoodwin/kamera/pkg/snapshot"
+	"github.com/tgoodwin/kamera/pkg/tag"
 	"github.com/tgoodwin/kamera/pkg/util"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -20,13 +21,15 @@ import (
 func newTestManager(rvLookup func(snapshot.VersionHash) int64) *manager {
 	store := snapshot.NewStore()
 	return &manager{
-		versionStore: NewVersionStore(store, nil),
-		effects:      make(map[string]reconcileEffects),
-		scheme:       runtime.NewScheme(),
-		effectRKeys:  make(map[string]util.Set[string]),
-		effectIKeys:  make(map[string]util.Set[snapshot.IdentityKey]),
-		effectRVs:    make(map[string]map[string]int64),
-		rvLookup:     rvLookup,
+		versionStore:   NewVersionStore(store, nil),
+		effects:        make(map[string]reconcileEffects),
+		scheme:         runtime.NewScheme(),
+		effectRKeys:    make(map[string]util.Set[string]),
+		effectIKeys:    make(map[string]util.Set[snapshot.IdentityKey]),
+		effectRVs:      make(map[string]map[string]int64),
+		effectVersions: make(map[string]map[string]snapshot.VersionHash),
+		effectNextRVs:  make(map[string]int64),
+		rvLookup:       rvLookup,
 	}
 }
 
@@ -139,12 +142,82 @@ func TestResourceVersionConflict_MultiWriteSameReconcile(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "7", currentObj.GetResourceVersion())
 
+	changes, err := mgr.GetEffects(ctx)
+	require.NoError(t, err)
+	require.Len(t, changes.Effects, 2)
+	require.Equal(t, int64(6), changes.Effects[0].ResourceVersion)
+	require.Equal(t, int64(7), changes.Effects[1].ResourceVersion)
+
 	// A separate copy retaining the original RV is now stale.
 	staleObj := makeObj("test-cm", "5")
 	staleObj.Object["data"] = map[string]any{"step": "3"}
 	err = mgr.RecordEffect(ctx, staleObj, event.UPDATE, nil, nil)
 	require.Error(t, err)
 	require.True(t, apierrors.IsConflict(err), "expected Conflict for stale RV, got: %v", err)
+}
+
+func TestResourceVersionConflict_NoOpPatchDoesNotStaleRetainedObject(t *testing.T) {
+	rvMap := make(map[snapshot.VersionHash]int64)
+	mgr := newTestManager(func(vh snapshot.VersionHash) int64 { return rvMap[vh] })
+
+	current := makeObj("test-cm", "")
+	tag.EnsureDeterministicIdentity(current)
+	currentHash := mgr.Publish(current)
+	rvMap[currentHash] = 5
+	key := snapshot.NewCompositeKeyWithGroup("", "ConfigMap", "default", "test-cm", "obj1")
+	ctx := ctxWithFrame("frame-no-op-patch")
+	require.NoError(t, mgr.PrepareEffectContext(ctx, ObjectVersions{key: currentHash}))
+
+	retained := current.DeepCopy()
+	retained.SetResourceVersion("5")
+	require.NoError(t, mgr.RecordEffect(ctx, retained.DeepCopy(), event.PATCH, nil, nil))
+	require.Equal(t, "5", retained.GetResourceVersion(), "no-op patch must not advance the retained object's RV")
+
+	retained.Object["data"] = map[string]any{"updated": "true"}
+	require.NoError(t, mgr.RecordEffect(ctx, retained, event.UPDATE, nil, nil))
+	require.Equal(t, "6", retained.GetResourceVersion())
+
+	changes, err := mgr.GetEffects(ctx)
+	require.NoError(t, err)
+	require.Len(t, changes.Effects, 1, "no-op patch must not materialize a write effect")
+	require.Equal(t, event.UPDATE, changes.Effects[0].OpType)
+}
+
+func TestResourceVersionSequenceUsesBranchFrontierAfterDeletion(t *testing.T) {
+	mgr := newTestManager(nil)
+	ctx := withResourceVersionBase(ctxWithFrame("frame-after-delete"), 10)
+	require.NoError(t, mgr.PrepareEffectContext(ctx, ObjectVersions{}))
+
+	created := makeObj("new-cm", "")
+	require.NoError(t, mgr.RecordEffect(ctx, created, event.CREATE, nil, nil))
+	require.Equal(t, "11", created.GetResourceVersion())
+
+	changes, err := mgr.GetEffects(ctx)
+	require.NoError(t, err)
+	require.Len(t, changes.Effects, 1)
+	require.Equal(t, int64(11), changes.Effects[0].ResourceVersion)
+}
+
+func TestResourceVersionSequenceIncludesRemoval(t *testing.T) {
+	mgr := newTestManager(nil)
+	current := makeObj("test-cm", "")
+	currentHash := mgr.Publish(current)
+	key := snapshot.NewCompositeKeyWithGroup("", "ConfigMap", "default", "test-cm", "obj1")
+	ctx := withResourceVersionBase(ctxWithFrame("frame-remove-create"), 5)
+	require.NoError(t, mgr.PrepareEffectContext(ctx, ObjectVersions{key: currentHash}))
+
+	require.NoError(t, mgr.RecordEffect(ctx, current.DeepCopy(), event.MARK_FOR_DELETION, nil, nil))
+	require.NoError(t, mgr.RecordEffect(ctx, current.DeepCopy(), event.REMOVE, nil, nil))
+	created := makeObj("test-cm", "")
+	require.NoError(t, mgr.RecordEffect(ctx, created, event.CREATE, nil, nil))
+
+	changes, err := mgr.GetEffects(ctx)
+	require.NoError(t, err)
+	require.Len(t, changes.Effects, 3)
+	require.Equal(t, int64(6), changes.Effects[0].ResourceVersion)
+	require.Equal(t, int64(7), changes.Effects[1].ResourceVersion)
+	require.Equal(t, int64(8), changes.Effects[2].ResourceVersion)
+	require.Equal(t, "8", created.GetResourceVersion())
 }
 
 func TestResourceVersionConflict_UpdateRequiresRV(t *testing.T) {

--- a/pkg/tracecheck/manager_rv_test.go
+++ b/pkg/tracecheck/manager_rv_test.go
@@ -13,6 +13,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // newTestManager creates a manager wired for RV conflict testing.
@@ -105,7 +106,7 @@ func TestResourceVersionConflict_CurrentWriteSucceeds(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// Test 3: Multi-write within same reconcile — all succeed against same baseline
+// Test 3: Successful writes advance RV within the reconcile.
 func TestResourceVersionConflict_MultiWriteSameReconcile(t *testing.T) {
 	rvMap := make(map[snapshot.VersionHash]int64)
 	mgr := newTestManager(func(vh snapshot.VersionHash) int64 { return rvMap[vh] })
@@ -125,25 +126,42 @@ func TestResourceVersionConflict_MultiWriteSameReconcile(t *testing.T) {
 	err := mgr.RecordEffect(ctx, objWithRV, event.GET, nil, nil)
 	require.NoError(t, err)
 
-	// First UPDATE with RV=5 — succeeds
-	patch1 := makeObj("test-cm", "5")
-	patch1.Object["data"] = map[string]any{"step": "1"}
-	err = mgr.RecordEffect(ctx, patch1, event.UPDATE, nil, nil)
+	// First UPDATE with RV=5 succeeds and receives the API server's next RV.
+	currentObj := makeObj("test-cm", "5")
+	currentObj.Object["data"] = map[string]any{"step": "1"}
+	err = mgr.RecordEffect(ctx, currentObj, event.UPDATE, nil, nil)
 	require.NoError(t, err)
+	require.Equal(t, "6", currentObj.GetResourceVersion())
 
-	// Second UPDATE also with RV=5 — succeeds (RV doesn't advance within a frame;
-	// all writes in the same reconcile are checked against the same ground truth baseline)
-	patch2 := makeObj("test-cm", "5")
-	patch2.Object["data"] = map[string]any{"step": "2"}
-	err = mgr.RecordEffect(ctx, patch2, event.UPDATE, nil, nil)
+	// Reusing the returned object carries RV=6 and succeeds again.
+	currentObj.Object["data"] = map[string]any{"step": "2"}
+	err = mgr.RecordEffect(ctx, currentObj, event.UPDATE, nil, nil)
 	require.NoError(t, err)
+	require.Equal(t, "7", currentObj.GetResourceVersion())
 
-	// UPDATE with wrong RV=99 — should fail
-	patch3 := makeObj("test-cm", "99")
-	patch3.Object["data"] = map[string]any{"step": "3"}
-	err = mgr.RecordEffect(ctx, patch3, event.UPDATE, nil, nil)
+	// A separate copy retaining the original RV is now stale.
+	staleObj := makeObj("test-cm", "5")
+	staleObj.Object["data"] = map[string]any{"step": "3"}
+	err = mgr.RecordEffect(ctx, staleObj, event.UPDATE, nil, nil)
 	require.Error(t, err)
-	require.True(t, apierrors.IsConflict(err), "expected Conflict for wrong RV, got: %v", err)
+	require.True(t, apierrors.IsConflict(err), "expected Conflict for stale RV, got: %v", err)
+}
+
+func TestResourceVersionConflict_UpdateRequiresRV(t *testing.T) {
+	rvMap := make(map[snapshot.VersionHash]int64)
+	mgr := newTestManager(func(vh snapshot.VersionHash) int64 { return rvMap[vh] })
+
+	obj := makeObj("test-cm", "")
+	hash := mgr.Publish(obj)
+	rvMap[hash] = 5
+
+	key := snapshot.NewCompositeKeyWithGroup("", "ConfigMap", "default", "test-cm", "obj1")
+	ctx := ctxWithFrame("frame-update-without-rv")
+	require.NoError(t, mgr.PrepareEffectContext(ctx, ObjectVersions{key: hash}))
+
+	err := mgr.RecordEffect(ctx, makeObj("test-cm", ""), event.UPDATE, nil, nil)
+	require.Error(t, err)
+	require.True(t, apierrors.IsInvalid(err), "expected Invalid for Update without RV, got: %v", err)
 }
 
 // Test 4: No-RV write succeeds
@@ -231,4 +249,33 @@ func TestResourceVersionStamping_DoReconcile(t *testing.T) {
 	require.Len(t, objects, 1)
 	u := objects[0].(*unstructured.Unstructured)
 	require.Equal(t, "42", u.GetResourceVersion(), "expected RV=42 stamped on served object")
+}
+
+func TestResourceVersionStamping_DistinguishesKindsWithSameName(t *testing.T) {
+	nn := types.NamespacedName{Namespace: "default", Name: "shared"}
+	configMap := makeObj("shared", "")
+	secret := makeObj("shared", "")
+	secret.SetKind("Secret")
+
+	configMapHash := snapshot.VersionHash{Value: "config-map"}
+	secretHash := snapshot.VersionHash{Value: "secret"}
+	versions := map[snapshot.VersionHash]int64{
+		configMapHash: 41,
+		secretHash:    73,
+	}
+	observable := ObjectVersions{
+		snapshot.NewCompositeKeyWithGroup("", "ConfigMap", nn.Namespace, nn.Name, "cm-id"):  configMapHash,
+		snapshot.NewCompositeKeyWithGroup("", "Secret", nn.Namespace, nn.Name, "secret-id"): secretHash,
+	}
+	frame := replay.CacheFrame{
+		"core/ConfigMap": {nn: configMap},
+		"core/Secret":    {nn: secret},
+	}
+
+	stampCacheFrameResourceVersions(frame, observable, func(hash snapshot.VersionHash) int64 {
+		return versions[hash]
+	})
+
+	require.Equal(t, "41", configMap.GetResourceVersion())
+	require.Equal(t, "73", secret.GetResourceVersion())
 }

--- a/pkg/tracecheck/reconciler.go
+++ b/pkg/tracecheck/reconciler.go
@@ -159,6 +159,38 @@ type ReconcilerContainer struct {
 	rvLookup func(snapshot.VersionHash) int64
 }
 
+type cacheObjectKey struct {
+	canonicalKind  string
+	namespacedName types.NamespacedName
+}
+
+func stampCacheFrameResourceVersions(frame replay.CacheFrame, observableState ObjectVersions, rvLookup func(snapshot.VersionHash) int64) {
+	if rvLookup == nil {
+		return
+	}
+
+	rvByKey := make(map[cacheObjectKey]int64, len(observableState))
+	for key, hash := range observableState {
+		if rv := rvLookup(hash); rv > 0 {
+			rvByKey[cacheObjectKey{
+				canonicalKind: util.CanonicalGroupKind(key.ResourceKey.Group, key.ResourceKey.Kind),
+				namespacedName: types.NamespacedName{
+					Namespace: key.ResourceKey.Namespace,
+					Name:      key.ResourceKey.Name,
+				},
+			}] = rv
+		}
+	}
+
+	for canonicalKind, objects := range frame {
+		for namespacedName, obj := range objects {
+			if rv, ok := rvByKey[cacheObjectKey{canonicalKind: canonicalKind, namespacedName: namespacedName}]; ok {
+				obj.SetResourceVersion(strconv.FormatInt(rv, 10))
+			}
+		}
+	}
+}
+
 func (r *ReconcilerContainer) doReconcile(ctx context.Context, observableState ObjectVersions, req reconcile.Request) (*ReconcileResult, error) {
 	frameID := replay.FrameIDFromContext(ctx)
 
@@ -181,27 +213,14 @@ func (r *ReconcilerContainer) doReconcile(ctx context.Context, observableState O
 		panic(errMsg)
 	}
 
-	// Build a name→RV map for stamping cache frame objects with resourceVersion.
+	// Stamp resourceVersions by full resource identity. Namespace/name alone is
+	// not unique because different resource kinds may share both values.
 	// This must be done on cache frame copies (not store copies) to avoid
 	// contaminating version hashes used for state comparison.
 	if r.rvLookup != nil {
 		if crs, ok := r.Strategy.(*ControllerRuntimeStrategy); ok {
-			rvByName := make(map[string]int64)
-			for key, hash := range observableState {
-				if rv := r.rvLookup(hash); rv > 0 {
-					nameKey := key.ResourceKey.Namespace + "/" + key.ResourceKey.Name
-					rvByName[nameKey] = rv
-				}
-			}
 			crs.rvStamper = func(frame replay.CacheFrame) {
-				for _, objs := range frame {
-					for nn, obj := range objs {
-						nameKey := nn.Namespace + "/" + nn.Name
-						if rv, ok := rvByName[nameKey]; ok {
-							obj.SetResourceVersion(strconv.FormatInt(rv, 10))
-						}
-					}
-				}
+				stampCacheFrameResourceVersions(frame, observableState, r.rvLookup)
 			}
 		}
 	}

--- a/pkg/tracecheck/staleness.go
+++ b/pkg/tracecheck/staleness.go
@@ -86,6 +86,13 @@ func (s *StateSnapshot) All() ObjectVersions {
 	return s.contents
 }
 
+func (s *StateSnapshot) highestSequence() int64 {
+	if len(s.stateEvents) == 0 {
+		return 0
+	}
+	return s.stateEvents[len(s.stateEvents)-1].Sequence
+}
+
 func (s *StateSnapshot) Observable() ObjectVersions {
 	ss := replayEventsAtSequence(s.stateEvents, s.KindSequences)
 	return ss.contents

--- a/pkg/tracecheck/tracecheck.go
+++ b/pkg/tracecheck/tracecheck.go
@@ -52,10 +52,12 @@ func NewTraceChecker(scheme *runtime.Scheme) *TraceChecker {
 	KnowledgeManager := NewKnowledgeManager(snapStore)
 
 	mgr := &manager{
-		versionStore: vStore,
-		effects:      make(map[string]reconcileEffects),
-		scheme:       scheme,
-		effectRVs:    make(map[string]map[string]int64),
+		versionStore:   vStore,
+		effects:        make(map[string]reconcileEffects),
+		scheme:         scheme,
+		effectRVs:      make(map[string]map[string]int64),
+		effectVersions: make(map[string]map[string]snapshot.VersionHash),
+		effectNextRVs:  make(map[string]int64),
 	}
 
 	return &TraceChecker{
@@ -143,8 +145,10 @@ func FromBuilder(b *replay.Builder) *TraceChecker {
 		effects:       make(map[string]reconcileEffects),
 		converterImpl: converter,
 		// TODO handle scheme properly
-		scheme:    nil,
-		effectRVs: make(map[string]map[string]int64),
+		scheme:         nil,
+		effectRVs:      make(map[string]map[string]int64),
+		effectVersions: make(map[string]map[string]snapshot.VersionHash),
+		effectNextRVs:  make(map[string]int64),
 	}
 
 	return &TraceChecker{

--- a/pkg/tracecheck/user_controller.go
+++ b/pkg/tracecheck/user_controller.go
@@ -77,8 +77,12 @@ func (r *userActionReconciler) Reconcile(ctx context.Context, req reconcile.Requ
 	if r.client == nil {
 		return reconcile.Result{}, fmt.Errorf("user action client is not configured")
 	}
+	if action.Payload == nil {
+		return reconcile.Result{}, fmt.Errorf("user action %q payload must implement client.Object", action.ID)
+	}
 
-	obj, ok := action.Payload.(client.Object)
+	payload := action.Payload.DeepCopyObject()
+	obj, ok := payload.(client.Object)
 	if !ok || obj == nil {
 		return reconcile.Result{}, fmt.Errorf("user action %q payload must implement client.Object", action.ID)
 	}

--- a/pkg/tracecheck/user_controller.go
+++ b/pkg/tracecheck/user_controller.go
@@ -90,6 +90,18 @@ func (r *userActionReconciler) Reconcile(ctx context.Context, req reconcile.Requ
 		}
 		return reconcile.Result{}, nil
 	case event.UPDATE:
+		// Workflow inputs describe the desired object and commonly omit the
+		// server-managed resourceVersion. Model the read-modify-write performed
+		// by a real API client before issuing Update, while preserving an
+		// explicitly supplied RV so scenarios can intentionally exercise stale
+		// user writes.
+		if obj.GetResourceVersion() == "" {
+			current := obj.DeepCopyObject().(client.Object)
+			if err := r.client.Get(ctx, client.ObjectKeyFromObject(obj), current); err != nil {
+				return reconcile.Result{}, err
+			}
+			obj.SetResourceVersion(current.GetResourceVersion())
+		}
 		if err := r.client.Update(ctx, obj); err != nil {
 			return reconcile.Result{}, err
 		}

--- a/pkg/tracecheck/user_controller_test.go
+++ b/pkg/tracecheck/user_controller_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/tgoodwin/kamera/pkg/event"
+	"github.com/tgoodwin/kamera/pkg/snapshot"
+	"github.com/tgoodwin/kamera/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -119,5 +121,50 @@ func TestUserActionReconciler_Reconcile_SelectsActionByRequestIndex(t *testing.T
 	}
 	if action.ID != "a1" {
 		t.Fatalf("expected action ID a1 from request index 1, got %q", action.ID)
+	}
+}
+
+func TestUserActionUpdatePayloadIsIsolatedAcrossBranches(t *testing.T) {
+	payload := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "shared"},
+		Data:       map[string]string{"desired": "value"},
+	}
+	builder := NewExplorerBuilder(runtime.NewScheme())
+	builder.WithUserActions([]UserAction{{ID: "update-shared", OpType: event.UPDATE, Payload: payload}})
+	explorer, err := builder.Build("standalone")
+	if err != nil {
+		t.Fatalf("build explorer: %v", err)
+	}
+
+	key := snapshot.NewCompositeKeyWithGroup("", "ConfigMap", "default", "shared", "obj1")
+	branchObject := func(value string, rv int64) ObjectVersions {
+		obj := &corev1.ConfigMap{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+			ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "shared"},
+			Data:       map[string]string{"branch": value},
+		}
+		u, convertErr := util.ConvertToUnstructured(obj)
+		if convertErr != nil {
+			t.Fatalf("convert branch object: %v", convertErr)
+		}
+		hash := explorer.versionManager.Publish(u)
+		explorer.resourceVersions[hash] = rv
+		return ObjectVersions{key: hash}
+	}
+
+	firstCtx := withResourceVersionBase(context.Background(), 5)
+	if _, err := explorer.userController.ExecuteNextAction(firstCtx, branchObject("one", 5), 0); err != nil {
+		t.Fatalf("execute first branch: %v", err)
+	}
+	if payload.GetResourceVersion() != "" {
+		t.Fatalf("first branch mutated shared payload RV to %q", payload.GetResourceVersion())
+	}
+
+	secondCtx := withResourceVersionBase(context.Background(), 9)
+	if _, err := explorer.userController.ExecuteNextAction(secondCtx, branchObject("two", 9), 0); err != nil {
+		t.Fatalf("execute second branch: %v", err)
+	}
+	if payload.GetResourceVersion() != "" {
+		t.Fatalf("second branch mutated shared payload RV to %q", payload.GetResourceVersion())
 	}
 }


### PR DESCRIPTION
## Summary

- key cache-frame resourceVersion stamping by full group/kind/namespace/name identity
- advance the simulated global resourceVersion after every successful in-frame API write
- return updated RVs on written objects and reject stale, missing, or invalid Update RVs
- model read-before-update for declarative user actions that omit server-managed RVs

## Why

The optimistic-concurrency implementation merged through #80 still allowed two fidelity gaps. Resources of different kinds sharing a namespace/name could receive each other's RV, and every write in one reconcile was checked against the same pre-reconcile baseline instead of observing successful earlier writes.

## Impact

Controllers now see API-server-like RV progression within a reconcile. Reusing an object returned from Update succeeds with its new RV, while a separate copy retaining the old RV conflicts. Ordinary merge patches remain unconditional, and workflow user actions remain ergonomic when their payloads omit resourceVersion.

## Validation

- `go test ./pkg/...`
- `go test ./...`

Closes yaks `key-rv-stamping-by-full-resource-identity-9nto` and `model-resourceversion-advancement-within-a-reconcile-dm8t`.
