### PR TITLE
add schema-backed server-side apply semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,28 @@ go run .
     eb.WithMaxDepth(100) // optional
     ```
 
+    For accurate Server-Side Apply behavior, also register the structural
+    schemas of resources that controllers write. A `runtime.Scheme` provides
+    Go types, but not Kubernetes merge topology:
+
+    ```go
+    eb.WithCRD(fooCRD) // preferred for CRDs
+    eb.WithResourceSchema(gvk, namespaced, hasStatus, openAPIV3Schema)
+    eb.WithOpenAPIV3(openAPIDocument) // built-in or aggregated APIs
+
+    // Optional: fail writes to any GVK whose schema was not registered.
+    eb.RequireSchemas()
+    ```
+
+    Registered, single-version resources use schema-aware SSA merging,
+    managed-field ownership, conflicts, force, omission, status isolation, and
+    generic metadata validation. Without `RequireSchemas`, unregistered GVKs
+    retain the legacy behavior to support incremental migration. Non-apply
+    patch ownership, dynamic and multi-version CRDs, admission, CEL, and the
+    complete API-server validation/defaulting pipeline remain outside this
+    milestone. See [Schema-backed API writes](docs/design/schema-backed-write-engine.md)
+    for the exact contract and limitations.
+
 4. **Register each controller-runtime reconciler.** Supply a factory that accepts a controller-runtime `client.Client`. The returned `ReconcilerBuilder` lets you chain `.For()` (primary resource) and `.Watches()` registrations. For non controller-runtime implementations, see [below](#using-non-controller-runtime-controllers).
 
     ```go

--- a/docs/design/schema-backed-write-engine.md
+++ b/docs/design/schema-backed-write-engine.md
@@ -1,0 +1,125 @@
+# Schema-backed API writes
+
+Kamera can opt individual Kubernetes resource versions into schema-backed API
+write semantics. For those resources, Server-Side Apply (SSA) is materialized
+with Kubernetes' upstream `managedfields` implementation before the controller
+client call returns. The committed exploration effect therefore contains the
+server result, not the partial apply configuration.
+
+This is the first milestone of [issue #82](https://github.com/tgoodwin/kamera/issues/82)
+and replaces the full-object APPLY behavior described by
+[issue #78](https://github.com/tgoodwin/kamera/issues/78) for registered GVKs.
+
+## Registering schemas
+
+Schema lookup uses the complete group, version, and kind. A Go `runtime.Scheme`
+is not enough because it does not retain Kubernetes merge topology such as
+list-map keys or atomic map behavior.
+
+Register CRDs when possible:
+
+```go
+builder := tracecheck.NewExplorerBuilder(scheme).
+    WithCRD(widgetCRD)
+```
+
+`WithCRD` registers a served version's structural schema, resource scope, and
+status-subresource availability. This milestone rejects CRDs with multiple
+served versions because exact cross-version ownership requires conversion.
+
+Built-in or aggregated resources can be registered from a structural schema:
+
+```go
+builder.WithResourceSchema(
+    corev1.SchemeGroupVersion.WithKind("ConfigMap"),
+    true,  // namespaced
+    false, // no status subresource
+    configMapSchema,
+)
+```
+
+A complete OpenAPI v3 document can also be registered with
+`WithOpenAPIV3(document)`. Its component schemas must contain
+`x-kubernetes-group-version-kind`. OpenAPI alone does not describe resource
+scope or whether status is a subresource, so `WithCRD` or
+`WithResourceSchema` is preferred when those details matter.
+
+Schema registration errors are returned by `Build` or
+`BuildStartStateFromObjects` rather than being deferred into exploration.
+
+## Strict and incremental modes
+
+Registration is incremental by default. A registered GVK uses the new engine;
+an unregistered GVK keeps Kamera's existing write behavior. This permits a
+harness to migrate one interaction hotspot at a time.
+
+Call `RequireSchemas()` to fail closed:
+
+```go
+builder := tracecheck.NewExplorerBuilder(scheme).
+    RequireSchemas().
+    WithCRD(widgetCRD)
+```
+
+In strict mode, the first mutating request whose GVK is not registered returns
+an error identifying the operation and GVK, along with the registration APIs.
+Reads and deletes do not need merge topology.
+
+Forked builders retain the same immutable schema configuration and strictness.
+The mutable ownership state is not kept in the registry; it lives in each
+object's `metadata.managedFields`, so it remains branch-local.
+
+## Modeled behavior for registered resources
+
+The first milestone models:
+
+- complete apply bodies from raw apply patches and typed apply configurations;
+- field manager, force, dry-run, field-validation, patch type, and subresource
+  request information;
+- schema-aware SSA merge topology using Kubernetes structured merge;
+- managed-field ownership, conflicts, force transfer, shared ownership, and
+  omission-based field removal;
+- ownership established and updated by CREATE and UPDATE;
+- main-resource and status APPLY isolation;
+- generic ObjectMeta and owner-reference validation after merging;
+- synchronous API errors before the controller follows its success path;
+- a frame-local live API view that advances across multiple writes in one
+  reconcile, while informer reads may remain stale;
+- generation and resource-version responses for materialized writes; and
+- commit-only handling in `applyEffects` for already materialized results.
+
+Fixture objects with no managed fields are processed through CREATE ownership
+using the deterministic manager `kamera-initial-state`. Existing
+`metadata.managedFields` from captured objects are preserved. If a registered
+resource exposes status, fixture status ownership is seeded separately with
+`kamera-initial-state-status`.
+
+Managed-field timestamps are cleared after upstream field management. They are
+observational wall-clock data that would otherwise distinguish identical
+exploration branches; managers, operations, API versions, subresources, and
+field sets are retained because they affect later writes.
+
+## Current limitations
+
+The schema is currently used for merge topology and managed fields, not as a
+complete API-server pipeline. This milestone does not yet provide structural
+defaulting, unknown-field pruning, structural/CEL validation, admission
+webhooks, conversion webhooks, or complete handwritten validation and
+defaulting for built-in resources.
+
+Non-apply JSON, merge, and strategic patches still use Kamera's legacy patch
+materialization path. Registered CREATE, UPDATE, APPLY, and status APPLY use the
+schema-backed engine; non-apply patch ownership will be added separately.
+During incremental migration, resource-version values returned by a registered
+write can be approximate if the same reconcile interleaves it with legacy
+writes. Strict, fully registered operation sequences advance synchronously.
+
+Registries are static for an exploration run. Creating, updating, or deleting a
+CRD during a branch does not yet change branch-local schema availability.
+Multi-version CRDs and OpenAPI documents are rejected rather than run with
+identity conversion. Scale subresources, aggregated API-server-specific
+behavior, and versioned built-in schema bundles are also outside this milestone.
+
+The Crossplane example registers ConfigMap explicitly because it is the shared
+composed resource involved in issue #78. Other Crossplane resource types remain
+on the legacy path until their schemas are registered.

--- a/examples/crossplane/go.mod
+++ b/examples/crossplane/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/tgoodwin/kamera v0.0.0
 	google.golang.org/protobuf v1.36.11
 	k8s.io/api v0.35.0
+	k8s.io/apiextensions-apiserver v0.35.0
 	k8s.io/apimachinery v0.35.0
 	sigs.k8s.io/controller-runtime v0.23.1
 )
@@ -110,7 +111,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apiextensions-apiserver v0.35.0 // indirect
 	k8s.io/apiserver v0.35.0 // indirect
 	k8s.io/client-go v0.35.0 // indirect
 	k8s.io/code-generator v0.35.0 // indirect

--- a/examples/crossplane/scenario.go
+++ b/examples/crossplane/scenario.go
@@ -25,6 +25,8 @@ import (
 	"github.com/tgoodwin/kamera/pkg/tag"
 	"github.com/tgoodwin/kamera/pkg/tracecheck"
 	sleevelog "github.com/tgoodwin/kamera/pkg/util/logger"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -44,6 +46,7 @@ const (
 
 func newCrossplaneExplorerBuilder() *tracecheck.ExplorerBuilder {
 	builder := tracecheck.NewExplorerBuilder(newScheme())
+	builder.WithResourceSchema(corev1.SchemeGroupVersion.WithKind("ConfigMap"), true, false, configMapOpenAPISchema())
 	log := logging.NewLogrLogger(sleevelog.GetLogger(sleevelog.Debug))
 	recorder := newLogRecorder(log)
 
@@ -100,6 +103,21 @@ func newCrossplaneExplorerBuilder() *tracecheck.ExplorerBuilder {
 		Watches("example.org/XWidget", claimXRToClaimMapper())
 
 	return builder
+}
+
+func configMapOpenAPISchema() *apiextensionsv1.JSONSchemaProps {
+	stringValues := &apiextensionsv1.JSONSchemaPropsOrBool{
+		Allows: true,
+		Schema: &apiextensionsv1.JSONSchemaProps{Type: "string"},
+	}
+	return &apiextensionsv1.JSONSchemaProps{
+		Type: "object",
+		Properties: map[string]apiextensionsv1.JSONSchemaProps{
+			"data":       {Type: "object", AdditionalProperties: stringValues},
+			"binaryData": {Type: "object", AdditionalProperties: stringValues.DeepCopy()},
+			"immutable":  {Type: "boolean"},
+		},
+	}
 }
 
 // deterministicNameGenerator generates a fixed name for XRs created by claims.

--- a/go.mod
+++ b/go.mod
@@ -28,10 +28,13 @@ require (
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	golang.org/x/tools v0.38.0
 	k8s.io/api v0.35.0
+	k8s.io/apiextensions-apiserver v0.35.0
 	k8s.io/apimachinery v0.35.0
 	k8s.io/client-go v0.35.0
+	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4
 	sigs.k8s.io/controller-runtime v0.23.0
+	sigs.k8s.io/structured-merge-diff/v6 v6.3.0
 	sigs.k8s.io/yaml v1.6.0
 )
 
@@ -106,10 +109,7 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apiextensions-apiserver v0.35.0 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
-	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
-	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
 )

--- a/pkg/apiserver/schema.go
+++ b/pkg/apiserver/schema.go
@@ -1,0 +1,386 @@
+package apiserver
+
+import (
+	"errors"
+	"fmt"
+	"maps"
+	"strings"
+
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	structuralschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
+	generatedopenapi "k8s.io/apiextensions-apiserver/pkg/generated/openapi"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/managedfields"
+	"k8s.io/kube-openapi/pkg/common"
+	"k8s.io/kube-openapi/pkg/spec3"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
+)
+
+// Registry stores immutable, schema-derived API write semantics by GVK.
+// Field ownership itself is stored in each object's metadata.managedFields.
+type Registry struct {
+	resources map[schema.GroupVersionKind]*ResourceSchema
+}
+
+// NewRegistry returns an empty schema registry.
+func NewRegistry() *Registry {
+	return &Registry{resources: make(map[schema.GroupVersionKind]*ResourceSchema)}
+}
+
+// Clone returns a shallow copy. ResourceSchema values are immutable after
+// construction and can safely be shared by forked explorers.
+func (r *Registry) Clone() *Registry {
+	if r == nil {
+		return NewRegistry()
+	}
+	return &Registry{resources: maps.Clone(r.resources)}
+}
+
+// Lookup returns registered write semantics for a GVK.
+func (r *Registry) Lookup(gvk schema.GroupVersionKind) (*ResourceSchema, bool) {
+	if r == nil {
+		return nil, false
+	}
+	rs, ok := r.resources[gvk]
+	return rs, ok
+}
+
+// RegisterCRD compiles every served CRD version into Kubernetes' upstream
+// structured-merge-diff type converter and field managers.
+func (r *Registry) RegisterCRD(crd *apiextensionsv1.CustomResourceDefinition) error {
+	if r == nil {
+		return errors.New("schema registry is nil")
+	}
+	if crd == nil {
+		return errors.New("CRD is nil")
+	}
+	servedVersions := 0
+	for _, version := range crd.Spec.Versions {
+		if version.Served {
+			servedVersions++
+		}
+	}
+	if servedVersions == 0 {
+		return fmt.Errorf("CRD %s has no served versions", crd.Name)
+	}
+	if servedVersions > 1 {
+		return fmt.Errorf("CRD %s has %d served versions; schema-backed writes currently require a single served version", crd.Name, servedVersions)
+	}
+
+	models := objectMetaModels()
+	for _, version := range crd.Spec.Versions {
+		if !version.Served {
+			continue
+		}
+		if version.Schema == nil || version.Schema.OpenAPIV3Schema == nil {
+			return fmt.Errorf("CRD %s version %s has no structural schema", crd.Name, version.Name)
+		}
+		root, err := resourceOpenAPISchema(
+			schema.GroupVersionKind{Group: crd.Spec.Group, Version: version.Name, Kind: crd.Spec.Names.Kind},
+			version.Schema.OpenAPIV3Schema,
+		)
+		if err != nil {
+			return fmt.Errorf("build structural schema for %s/%s: %w", crd.Name, version.Name, err)
+		}
+		models[resourceModelName(crd.Spec.Group, version.Name, crd.Spec.Names.Kind)] = root
+	}
+	typeConverter, err := managedfields.NewTypeConverter(models, crd.Spec.PreserveUnknownFields)
+	if err != nil {
+		return fmt.Errorf("build type converter for %s: %w", crd.Name, err)
+	}
+
+	namespaced := crd.Spec.Scope == apiextensionsv1.NamespaceScoped
+	for _, version := range crd.Spec.Versions {
+		if !version.Served {
+			continue
+		}
+		gvk := schema.GroupVersionKind{Group: crd.Spec.Group, Version: version.Name, Kind: crd.Spec.Names.Kind}
+		hasStatus := version.Subresources != nil && version.Subresources.Status != nil
+		rs, err := newResourceSchema(gvk, namespaced, hasStatus, typeConverter)
+		if err != nil {
+			return fmt.Errorf("configure field manager for %s: %w", gvk, err)
+		}
+		r.resources[gvk] = rs
+	}
+	return nil
+}
+
+func resourceOpenAPISchema(gvk schema.GroupVersionKind, input *apiextensionsv1.JSONSchemaProps) (*spec.Schema, error) {
+	internal := &apiextensions.JSONSchemaProps{}
+	if err := apiextensionsv1.Convert_v1_JSONSchemaProps_To_apiextensions_JSONSchemaProps(input, internal, nil); err != nil {
+		return nil, err
+	}
+	structural, err := structuralschema.NewStructural(internal)
+	if err != nil {
+		return nil, err
+	}
+	root := structural.ToKubeOpenAPI()
+	if root.Properties == nil {
+		root.Properties = make(map[string]spec.Schema)
+	}
+	root.Properties["apiVersion"] = *spec.StringProperty()
+	root.Properties["kind"] = *spec.StringProperty()
+	root.Properties["metadata"] = *spec.RefSchema(objectMetaRef())
+	root.AddExtension("x-kubernetes-group-version-kind", []interface{}{
+		map[string]interface{}{
+			"group": gvk.Group, "version": gvk.Version, "kind": gvk.Kind,
+		},
+	})
+	return root, nil
+}
+
+func resourceModelName(group, version, kind string) string {
+	if group == "" {
+		group = "core"
+	}
+	return fmt.Sprintf("io.k8s.kamera.%s.%s.%s", strings.ReplaceAll(group, ".", "_"), version, kind)
+}
+
+func objectMetaRef() string {
+	return "#/definitions/" + common.EscapeJsonPointer(metav1.ObjectMeta{}.OpenAPIModelName())
+}
+
+func objectMetaModels() map[string]*spec.Schema {
+	definitions := generatedopenapi.GetOpenAPIDefinitions(func(name string) spec.Ref {
+		return spec.MustCreateRef("#/definitions/" + common.EscapeJsonPointer(name))
+	})
+	models := make(map[string]*spec.Schema, len(definitions))
+	for name, definition := range definitions {
+		model := definition.Schema
+		models[name] = &model
+	}
+	return models
+}
+
+// RegisterResourceSchema registers one resource version from structural
+// JSONSchemaProps. It is useful for built-in or aggregated resources when a
+// complete group-version OpenAPI document is not readily available.
+func (r *Registry) RegisterResourceSchema(
+	gvk schema.GroupVersionKind,
+	namespaced bool,
+	hasStatus bool,
+	openAPIV3Schema *apiextensionsv1.JSONSchemaProps,
+) error {
+	if openAPIV3Schema == nil {
+		return fmt.Errorf("schema for %s is nil", gvk)
+	}
+	plural := strings.ToLower(gvk.Kind) + "s"
+	crd := &apiextensionsv1.CustomResourceDefinition{
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: gvk.Group,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Kind:     gvk.Kind,
+				ListKind: gvk.Kind + "List",
+				Plural:   plural,
+				Singular: strings.ToLower(gvk.Kind),
+			},
+			Scope: apiextensionsv1.ClusterScoped,
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{{
+				Name:    gvk.Version,
+				Served:  true,
+				Storage: true,
+				Schema: &apiextensionsv1.CustomResourceValidation{
+					OpenAPIV3Schema: openAPIV3Schema.DeepCopy(),
+				},
+			}},
+		},
+	}
+	if namespaced {
+		crd.Spec.Scope = apiextensionsv1.NamespaceScoped
+	}
+	if hasStatus {
+		crd.Spec.Versions[0].Subresources = &apiextensionsv1.CustomResourceSubresources{
+			Status: &apiextensionsv1.CustomResourceSubresourceStatus{},
+		}
+	}
+	return r.RegisterCRD(crd)
+}
+
+// RegisterOpenAPIV3 registers every GVK described by a complete OpenAPI v3
+// document. Resource scope and status-subresource availability are not present
+// in OpenAPI, so callers that need exact metadata/subresource behavior should
+// prefer RegisterCRD or RegisterResourceSchema.
+func (r *Registry) RegisterOpenAPIV3(doc *spec3.OpenAPI) error {
+	if r == nil {
+		return errors.New("schema registry is nil")
+	}
+	if doc == nil || doc.Components == nil {
+		return errors.New("OpenAPI v3 document has no components")
+	}
+	typeConverter, err := managedfields.NewTypeConverter(doc.Components.Schemas, false)
+	if err != nil {
+		return fmt.Errorf("build OpenAPI type converter: %w", err)
+	}
+
+	registered := 0
+	groupKinds := make(map[schema.GroupKind]schema.GroupVersionKind)
+	for _, model := range doc.Components.Schemas {
+		for _, gvk := range schemaGVKs(model) {
+			if previous, found := groupKinds[gvk.GroupKind()]; found && previous.Version != gvk.Version {
+				return fmt.Errorf("OpenAPI document contains multiple versions for %s (%s and %s); schema-backed writes currently require one version", gvk.GroupKind(), previous.Version, gvk.Version)
+			}
+			groupKinds[gvk.GroupKind()] = gvk
+			rs, err := newResourceSchema(gvk, true, false, typeConverter)
+			if err != nil {
+				return fmt.Errorf("configure field manager for %s: %w", gvk, err)
+			}
+			r.resources[gvk] = rs
+			registered++
+		}
+	}
+	if registered == 0 {
+		return errors.New("OpenAPI v3 document contains no x-kubernetes-group-version-kind schemas")
+	}
+	return nil
+}
+
+func schemaGVKs(model *spec.Schema) []schema.GroupVersionKind {
+	if model == nil {
+		return nil
+	}
+	raw, ok := model.Extensions["x-kubernetes-group-version-kind"]
+	if !ok {
+		return nil
+	}
+	var out []schema.GroupVersionKind
+	appendGVK := func(group, version, kind string) {
+		if version != "" && kind != "" {
+			out = append(out, schema.GroupVersionKind{Group: group, Version: version, Kind: kind})
+		}
+	}
+	switch values := raw.(type) {
+	case []map[string]string:
+		for _, value := range values {
+			appendGVK(value["group"], value["version"], value["kind"])
+		}
+	case []interface{}:
+		for _, item := range values {
+			switch value := item.(type) {
+			case map[string]interface{}:
+				group, _ := value["group"].(string)
+				version, _ := value["version"].(string)
+				kind, _ := value["kind"].(string)
+				appendGVK(group, version, kind)
+			case map[interface{}]interface{}:
+				group, _ := value["group"].(string)
+				version, _ := value["version"].(string)
+				kind, _ := value["kind"].(string)
+				appendGVK(group, version, kind)
+			}
+		}
+	}
+	return out
+}
+
+// ResourceSchema contains the immutable schema machinery for one GVK.
+type ResourceSchema struct {
+	GVK           schema.GroupVersionKind
+	Namespaced    bool
+	HasStatus     bool
+	mainManager   *managedfields.FieldManager
+	statusManager *managedfields.FieldManager
+}
+
+func newResourceSchema(
+	gvk schema.GroupVersionKind,
+	namespaced bool,
+	hasStatus bool,
+	typeConverter managedfields.TypeConverter,
+) (*ResourceSchema, error) {
+	converter := unstructuredObjectConverter{}
+	defaulter := unstructuredDefaulter{}
+	creator := unstructuredCreator{}
+	apiVersion := fieldpath.APIVersion(gvk.GroupVersion().String())
+
+	mainReset := map[fieldpath.APIVersion]*fieldpath.Set{}
+	if hasStatus {
+		mainReset[apiVersion] = fieldpath.NewSet(fieldpath.MakePathOrDie("status"))
+	}
+	mainManager, err := managedfields.NewDefaultCRDFieldManager(
+		typeConverter,
+		converter,
+		defaulter,
+		creator,
+		gvk,
+		gvk.GroupVersion(),
+		"",
+		fieldpath.NewExcludeFilterSetMap(mainReset),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var statusManager *managedfields.FieldManager
+	if hasStatus {
+		statusReset := map[fieldpath.APIVersion]*fieldpath.Set{
+			apiVersion: fieldpath.NewSet(fieldpath.MakePathOrDie("spec")),
+		}
+		statusManager, err = managedfields.NewDefaultCRDFieldManager(
+			typeConverter,
+			converter,
+			defaulter,
+			creator,
+			gvk,
+			gvk.GroupVersion(),
+			"status",
+			fieldpath.NewExcludeFilterSetMap(statusReset),
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &ResourceSchema{
+		GVK:           gvk,
+		Namespaced:    namespaced,
+		HasStatus:     hasStatus,
+		mainManager:   mainManager,
+		statusManager: statusManager,
+	}, nil
+}
+
+type unstructuredCreator struct{}
+
+func (unstructuredCreator) New(gvk schema.GroupVersionKind) (runtime.Object, error) {
+	return newUnstructured(gvk), nil
+}
+
+type unstructuredDefaulter struct{}
+
+func (unstructuredDefaulter) Default(runtime.Object) {}
+
+type unstructuredObjectConverter struct{}
+
+func (unstructuredObjectConverter) Convert(in, out, _ interface{}) error {
+	src, ok := in.(runtime.Unstructured)
+	if !ok {
+		return fmt.Errorf("convert input %T is not unstructured", in)
+	}
+	dst, ok := out.(runtime.Unstructured)
+	if !ok {
+		return fmt.Errorf("convert output %T is not unstructured", out)
+	}
+	dst.SetUnstructuredContent(runtime.DeepCopyJSON(src.UnstructuredContent()))
+	return nil
+}
+
+func (unstructuredObjectConverter) ConvertToVersion(in runtime.Object, target runtime.GroupVersioner) (runtime.Object, error) {
+	src, ok := in.(runtime.Unstructured)
+	if !ok {
+		return nil, fmt.Errorf("convert input %T is not unstructured", in)
+	}
+	copy := newUnstructured(src.GetObjectKind().GroupVersionKind())
+	copy.SetUnstructuredContent(runtime.DeepCopyJSON(src.UnstructuredContent()))
+	if kind, ok := target.KindForGroupVersionKinds([]schema.GroupVersionKind{copy.GroupVersionKind()}); ok {
+		copy.SetGroupVersionKind(kind)
+	}
+	return copy, nil
+}
+
+func (unstructuredObjectConverter) ConvertFieldLabel(schema.GroupVersionKind, string, string) (string, string, error) {
+	return "", "", errors.New("field label conversion is not implemented")
+}

--- a/pkg/apiserver/unstructured.go
+++ b/pkg/apiserver/unstructured.go
@@ -1,0 +1,12 @@
+package apiserver
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func newUnstructured(gvk schema.GroupVersionKind) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{}}
+	obj.SetGroupVersionKind(gvk)
+	return obj
+}

--- a/pkg/apiserver/write_engine.go
+++ b/pkg/apiserver/write_engine.go
@@ -1,0 +1,248 @@
+package apiserver
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/tgoodwin/kamera/pkg/tag"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apivalidation "k8s.io/apimachinery/pkg/api/validation"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/managedfields"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// Apply materializes one server-side apply request against the live object.
+// A nil live object uses SSA create semantics.
+func (s *ResourceSchema) Apply(
+	live *unstructured.Unstructured,
+	intent *unstructured.Unstructured,
+	manager string,
+	force bool,
+	subresource string,
+) (*unstructured.Unstructured, error) {
+	if manager == "" {
+		return nil, apierrors.NewBadRequest("fieldManager is required for server-side apply")
+	}
+	if intent == nil {
+		return nil, apierrors.NewBadRequest("apply configuration is nil")
+	}
+	if intent.GroupVersionKind() != s.GVK {
+		return nil, apierrors.NewBadRequest(fmt.Sprintf(
+			"apply configuration GVK %s does not match registered schema %s",
+			intent.GroupVersionKind(), s.GVK,
+		))
+	}
+
+	creating := live == nil
+	base := live
+	if base == nil {
+		base = newUnstructured(s.GVK)
+	}
+
+	fieldManager, err := s.managerFor(subresource)
+	if err != nil {
+		return nil, err
+	}
+	result, err := fieldManager.Apply(base.DeepCopy(), intent.DeepCopy(), manager, force)
+	if err != nil {
+		return nil, err
+	}
+	merged, err := asUnstructured(result)
+	if err != nil {
+		return nil, err
+	}
+	merged = s.enforceSubresource(base, merged, subresource, creating)
+	normalizeManagedFieldTimes(merged)
+	s.finishServerMetadata(base, merged, subresource, creating)
+	if err := s.validate(merged, base, creating); err != nil {
+		return nil, err
+	}
+	return merged, nil
+}
+
+// Create materializes field ownership for a newly-created object.
+func (s *ResourceSchema) Create(
+	desired *unstructured.Unstructured,
+	manager string,
+) (*unstructured.Unstructured, error) {
+	if desired == nil {
+		return nil, apierrors.NewBadRequest("create object is nil")
+	}
+	base := newUnstructured(s.GVK)
+	prepared := desired.DeepCopy()
+	if s.HasStatus {
+		delete(prepared.Object, "status")
+	}
+	result, err := s.mainManager.Update(base, prepared, manager)
+	if err != nil {
+		return nil, err
+	}
+	created, err := asUnstructured(result)
+	if err != nil {
+		return nil, err
+	}
+	normalizeManagedFieldTimes(created)
+	s.finishServerMetadata(base, created, "", true)
+	if err := s.validate(created, base, true); err != nil {
+		return nil, err
+	}
+	return created, nil
+}
+
+// Update updates managed fields after a full-object or already-materialized
+// non-apply write. Patch documents must be materialized before calling Update.
+func (s *ResourceSchema) Update(
+	live *unstructured.Unstructured,
+	desired *unstructured.Unstructured,
+	manager string,
+	subresource string,
+) (*unstructured.Unstructured, error) {
+	if live == nil {
+		return nil, apierrors.NewNotFound(schema.GroupResource{Group: s.GVK.Group, Resource: s.GVK.Kind}, desired.GetName())
+	}
+	fieldManager, err := s.managerFor(subresource)
+	if err != nil {
+		return nil, err
+	}
+	prepared := s.enforceSubresource(live, desired.DeepCopy(), subresource, false)
+	result, err := fieldManager.Update(live.DeepCopy(), prepared, manager)
+	if err != nil {
+		return nil, err
+	}
+	updated, err := asUnstructured(result)
+	if err != nil {
+		return nil, err
+	}
+	updated = s.enforceSubresource(live, updated, subresource, false)
+	normalizeManagedFieldTimes(updated)
+	s.finishServerMetadata(live, updated, subresource, false)
+	if err := s.validate(updated, live, false); err != nil {
+		return nil, err
+	}
+	return updated, nil
+}
+
+func (s *ResourceSchema) managerFor(subresource string) (*managedfields.FieldManager, error) {
+	switch subresource {
+	case "":
+		return s.mainManager, nil
+	case "status":
+		if !s.HasStatus || s.statusManager == nil {
+			return nil, apierrors.NewBadRequest(fmt.Sprintf("%s does not expose a status subresource", s.GVK))
+		}
+		return s.statusManager, nil
+	default:
+		return nil, apierrors.NewBadRequest(fmt.Sprintf("unsupported subresource %q for %s", subresource, s.GVK))
+	}
+}
+
+func (s *ResourceSchema) enforceSubresource(
+	live *unstructured.Unstructured,
+	candidate *unstructured.Unstructured,
+	subresource string,
+	creating bool,
+) *unstructured.Unstructured {
+	if creating {
+		if s.HasStatus && subresource == "" {
+			delete(candidate.Object, "status")
+		}
+		return candidate
+	}
+	if subresource == "status" {
+		result := live.DeepCopy()
+		if status, found := candidate.Object["status"]; found {
+			result.Object["status"] = runtime.DeepCopyJSONValue(status)
+		} else {
+			delete(result.Object, "status")
+		}
+		result.SetManagedFields(candidate.GetManagedFields())
+		return result
+	}
+	if s.HasStatus {
+		if status, found := live.Object["status"]; found {
+			candidate.Object["status"] = runtime.DeepCopyJSONValue(status)
+		} else {
+			delete(candidate.Object, "status")
+		}
+	}
+	return candidate
+}
+
+func (s *ResourceSchema) finishServerMetadata(
+	live *unstructured.Unstructured,
+	result *unstructured.Unstructured,
+	subresource string,
+	creating bool,
+) {
+	result.SetGroupVersionKind(s.GVK)
+	if creating {
+		tag.EnsureDeterministicIdentity(result)
+		if result.GetResourceVersion() == "" {
+			result.SetResourceVersion("1")
+		}
+		if result.GetGeneration() == 0 {
+			result.SetGeneration(1)
+		}
+		return
+	}
+
+	result.SetUID(live.GetUID())
+	result.SetCreationTimestamp(live.GetCreationTimestamp())
+	result.SetResourceVersion(live.GetResourceVersion())
+	if subresource == "status" {
+		result.SetGeneration(live.GetGeneration())
+		return
+	}
+	if !reflect.DeepEqual(live.Object["spec"], result.Object["spec"]) {
+		generation := live.GetGeneration()
+		if generation == 0 {
+			generation = 1
+		} else {
+			generation++
+		}
+		result.SetGeneration(generation)
+	} else {
+		result.SetGeneration(live.GetGeneration())
+	}
+}
+
+func (s *ResourceSchema) validate(
+	result *unstructured.Unstructured,
+	live *unstructured.Unstructured,
+	creating bool,
+) error {
+	path := field.NewPath("metadata")
+	var errs field.ErrorList
+	if creating {
+		errs = apivalidation.ValidateObjectMetaAccessor(result, s.Namespaced, apivalidation.NameIsDNSSubdomain, path)
+	} else {
+		errs = apivalidation.ValidateObjectMetaAccessorUpdate(result, live, path)
+		errs = append(errs, apivalidation.ValidateOwnerReferences(result.GetOwnerReferences(), path.Child("ownerReferences"))...)
+	}
+	if len(errs) > 0 {
+		return apierrors.NewInvalid(s.GVK.GroupKind(), result.GetName(), errs)
+	}
+	return nil
+}
+
+func asUnstructured(obj runtime.Object) (*unstructured.Unstructured, error) {
+	result, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		return nil, fmt.Errorf("managed fields returned %T, want *unstructured.Unstructured", obj)
+	}
+	return result, nil
+}
+
+func normalizeManagedFieldTimes(obj *unstructured.Unstructured) {
+	entries := obj.GetManagedFields()
+	for idx := range entries {
+		// Wall-clock timestamps are observational metadata and would make equal
+		// exploration branches hash differently. Ownership and operation data
+		// remain byte-for-byte compatible with Kubernetes managedFields.
+		entries[idx].Time = nil
+	}
+	obj.SetManagedFields(entries)
+}

--- a/pkg/apiserver/write_engine_test.go
+++ b/pkg/apiserver/write_engine_test.go
@@ -1,0 +1,258 @@
+package apiserver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var testGVK = schema.GroupVersionKind{Group: "testing.kamera.io", Version: "v1", Kind: "Widget"}
+
+func testResourceSchema(t *testing.T, hasStatus bool) *ResourceSchema {
+	t.Helper()
+	registry := NewRegistry()
+	require.NoError(t, registry.RegisterResourceSchema(testGVK, true, hasStatus, &apiextensionsv1.JSONSchemaProps{
+		Type: "object",
+		Properties: map[string]apiextensionsv1.JSONSchemaProps{
+			"spec": {
+				Type: "object",
+				Properties: map[string]apiextensionsv1.JSONSchemaProps{
+					"first":  {Type: "string"},
+					"second": {Type: "string"},
+					"items": {
+						Type:         "array",
+						XListType:    stringPtr("map"),
+						XListMapKeys: []string{"name"},
+						Items: &apiextensionsv1.JSONSchemaPropsOrArray{
+							Schema: &apiextensionsv1.JSONSchemaProps{
+								Type: "object",
+								Properties: map[string]apiextensionsv1.JSONSchemaProps{
+									"name":  {Type: "string"},
+									"value": {Type: "string"},
+								},
+							},
+						},
+					},
+					"atomic": {
+						Type:     "object",
+						XMapType: stringPtr("atomic"),
+						Properties: map[string]apiextensionsv1.JSONSchemaProps{
+							"alpha": {Type: "string"},
+							"beta":  {Type: "string"},
+						},
+					},
+					"tags": {
+						Type:      "array",
+						XListType: stringPtr("set"),
+						Items: &apiextensionsv1.JSONSchemaPropsOrArray{
+							Schema: &apiextensionsv1.JSONSchemaProps{Type: "string"},
+						},
+					},
+				},
+			},
+			"status": {
+				Type: "object",
+				Properties: map[string]apiextensionsv1.JSONSchemaProps{
+					"phase": {Type: "string"},
+				},
+			},
+		},
+	}))
+	rs, ok := registry.Lookup(testGVK)
+	require.True(t, ok)
+	return rs
+}
+
+func stringPtr(value string) *string { return &value }
+
+func widget(name string, fields map[string]interface{}) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": testGVK.GroupVersion().String(),
+		"kind":       testGVK.Kind,
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": "default",
+		},
+	}}
+	for key, value := range fields {
+		obj.Object[key] = value
+	}
+	return obj
+}
+
+func TestApplyUsesSchemaTopologyAndManagedOwnership(t *testing.T) {
+	rs := testResourceSchema(t, false)
+	live, err := rs.Create(widget("example", map[string]interface{}{
+		"spec": map[string]interface{}{"first": "one"},
+	}), "creator")
+	require.NoError(t, err)
+	require.NotEmpty(t, live.GetManagedFields())
+
+	merged, err := rs.Apply(live, widget("example", map[string]interface{}{
+		"spec": map[string]interface{}{
+			"second": "two",
+			"items": []interface{}{
+				map[string]interface{}{"name": "a", "value": "one"},
+			},
+		},
+	}), "second-manager", false, "")
+	require.NoError(t, err)
+	require.Equal(t, "one", merged.Object["spec"].(map[string]interface{})["first"])
+	require.Equal(t, "two", merged.Object["spec"].(map[string]interface{})["second"])
+
+	merged, err = rs.Apply(merged, widget("example", map[string]interface{}{
+		"spec": map[string]interface{}{
+			"second": "two",
+			"items": []interface{}{
+				map[string]interface{}{"name": "b", "value": "two"},
+			},
+		},
+	}), "third-manager", false, "")
+	require.NoError(t, err)
+	require.Len(t, merged.Object["spec"].(map[string]interface{})["items"], 2)
+}
+
+func TestApplyConflictForceAndOmission(t *testing.T) {
+	rs := testResourceSchema(t, false)
+	live, err := rs.Apply(nil, widget("example", map[string]interface{}{
+		"spec": map[string]interface{}{"first": "one"},
+	}), "first-manager", false, "")
+	require.NoError(t, err)
+
+	_, err = rs.Apply(live, widget("example", map[string]interface{}{
+		"spec": map[string]interface{}{"first": "two"},
+	}), "second-manager", false, "")
+	require.True(t, apierrors.IsConflict(err), "expected conflict, got %v", err)
+
+	forced, err := rs.Apply(live, widget("example", map[string]interface{}{
+		"spec": map[string]interface{}{"first": "two"},
+	}), "second-manager", true, "")
+	require.NoError(t, err)
+	require.Equal(t, "two", forced.Object["spec"].(map[string]interface{})["first"])
+
+	omitted, err := rs.Apply(forced, widget("example", nil), "second-manager", false, "")
+	require.NoError(t, err)
+	_, hasSpec := omitted.Object["spec"]
+	require.False(t, hasSpec, "solely-owned omitted field should be removed")
+}
+
+func TestApplySharedOwnershipAndTrueNoOp(t *testing.T) {
+	rs := testResourceSchema(t, false)
+	live, err := rs.Apply(nil, widget("example", map[string]interface{}{
+		"spec": map[string]interface{}{"first": "one"},
+	}), "first-manager", false, "")
+	require.NoError(t, err)
+
+	shared, err := rs.Apply(live, widget("example", map[string]interface{}{
+		"spec": map[string]interface{}{"first": "one"},
+	}), "second-manager", false, "")
+	require.NoError(t, err)
+	require.Len(t, shared.GetManagedFields(), 2)
+
+	relinquished, err := rs.Apply(shared, widget("example", nil), "first-manager", false, "")
+	require.NoError(t, err)
+	require.Equal(t, "one", relinquished.Object["spec"].(map[string]interface{})["first"])
+
+	unchanged, err := rs.Apply(relinquished, widget("example", map[string]interface{}{
+		"spec": map[string]interface{}{"first": "one"},
+	}), "second-manager", false, "")
+	require.NoError(t, err)
+	require.Equal(t, relinquished.Object, unchanged.Object)
+}
+
+func TestApplyHonorsAtomicMapAndSetListTopology(t *testing.T) {
+	rs := testResourceSchema(t, false)
+	live, err := rs.Apply(nil, widget("example", map[string]interface{}{
+		"spec": map[string]interface{}{
+			"atomic": map[string]interface{}{"alpha": "one"},
+			"tags":   []interface{}{"a"},
+		},
+	}), "first-manager", false, "")
+	require.NoError(t, err)
+
+	_, err = rs.Apply(live, widget("example", map[string]interface{}{
+		"spec": map[string]interface{}{
+			"atomic": map[string]interface{}{"beta": "two"},
+		},
+	}), "second-manager", false, "")
+	require.True(t, apierrors.IsConflict(err), "atomic map should conflict as one field: %v", err)
+
+	merged, err := rs.Apply(live, widget("example", map[string]interface{}{
+		"spec": map[string]interface{}{
+			"tags": []interface{}{"b"},
+		},
+	}), "second-manager", false, "")
+	require.NoError(t, err)
+	require.ElementsMatch(t, []interface{}{"a", "b"}, merged.Object["spec"].(map[string]interface{})["tags"])
+}
+
+func TestApplyMergesOwnerReferencesThenRejectsMultipleControllers(t *testing.T) {
+	rs := testResourceSchema(t, false)
+	controller := true
+	block := true
+	ownerA := metav1.OwnerReference{
+		APIVersion: "testing.kamera.io/v1", Kind: "Owner", Name: "a", UID: types.UID("owner-a"),
+		Controller: &controller, BlockOwnerDeletion: &block,
+	}
+	ownerB := metav1.OwnerReference{
+		APIVersion: "testing.kamera.io/v1", Kind: "Owner", Name: "b", UID: types.UID("owner-b"),
+		Controller: &controller, BlockOwnerDeletion: &block,
+	}
+
+	first := widget("example", nil)
+	first.SetOwnerReferences([]metav1.OwnerReference{ownerA})
+	live, err := rs.Apply(nil, first, "owner-a-manager", true, "")
+	require.NoError(t, err)
+
+	second := widget("example", nil)
+	second.SetOwnerReferences([]metav1.OwnerReference{ownerB})
+	_, err = rs.Apply(live, second, "owner-b-manager", true, "")
+	require.True(t, apierrors.IsInvalid(err), "ForceOwnership must not bypass metadata validation: %v", err)
+}
+
+func TestStatusApplyPreservesSpecAndGeneration(t *testing.T) {
+	rs := testResourceSchema(t, true)
+	live, err := rs.Apply(nil, widget("example", map[string]interface{}{
+		"spec": map[string]interface{}{"first": "one"},
+	}), "spec-manager", false, "")
+	require.NoError(t, err)
+	live.SetGeneration(7)
+
+	status, err := rs.Apply(live, widget("example", map[string]interface{}{
+		"status": map[string]interface{}{"phase": "Ready"},
+	}), "status-manager", false, "status")
+	require.NoError(t, err)
+	require.Equal(t, "one", status.Object["spec"].(map[string]interface{})["first"])
+	require.Equal(t, "Ready", status.Object["status"].(map[string]interface{})["phase"])
+	require.Equal(t, int64(7), status.GetGeneration())
+	require.Condition(t, func() bool {
+		for _, entry := range status.GetManagedFields() {
+			if entry.Manager == "status-manager" && entry.Subresource == "status" {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+func TestRegisterCRDRejectsMultipleServedVersionsWithoutConversion(t *testing.T) {
+	registry := NewRegistry()
+	crd := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "widgets.testing.kamera.io"},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: "testing.kamera.io",
+			Names: apiextensionsv1.CustomResourceDefinitionNames{Kind: "Widget", Plural: "widgets"},
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+				{Name: "v1", Served: true, Storage: true},
+				{Name: "v2", Served: true},
+			},
+		},
+	}
+	require.ErrorContains(t, registry.RegisterCRD(crd), "currently require a single served version")
+}

--- a/pkg/replay/client.go
+++ b/pkg/replay/client.go
@@ -2,6 +2,7 @@ package replay
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
@@ -20,10 +21,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/yaml"
 )
 
 var logger logr.Logger
@@ -178,7 +179,18 @@ func extractMergePatchRV(_ client.Object, patch client.Patch, preconditions *Pre
 
 func (c *Client) handleEffect(ctx context.Context, obj client.Object, opType event.OperationType, preconditions *PreconditionInfo, options *EffectOptions) error {
 	// TODO validate preconditions
-	tag.EnsureDeterministicIdentity(obj)
+	if opType != event.APPLY {
+		tag.EnsureDeterministicIdentity(obj)
+	}
+	if preconditions != nil && preconditions.FieldManager == "" && opType != event.APPLY {
+		preconditions.FieldManager = c.reconcilerID
+	}
+	if event.IsWriteOp(opType) {
+		if options == nil {
+			options = &EffectOptions{}
+		}
+		options.ReconcilerID = c.reconcilerID
+	}
 	return c.recorder.RecordEffect(ctx, obj, opType, preconditions, options)
 }
 
@@ -229,7 +241,7 @@ func (c *Client) Get(ctx context.Context, key client.ObjectKey, obj client.Objec
 		return apierrors.NewNotFound(schema.GroupResource{Group: gvk.Group, Resource: gvk.Kind}, key.Name)
 	}
 
-		if err := c.handleEffect(ctx, frozenObj, event.GET, nil, nil); err != nil {
+	if err := c.handleEffect(ctx, frozenObj, event.GET, nil, nil); err != nil {
 		logger.V(1).Error(err,
 			"canonicalKind", canonicalKind,
 			"namespace", key.Namespace,
@@ -388,7 +400,18 @@ func (c *Client) Patch(ctx context.Context, obj client.Object, patch client.Patc
 	if op == event.PATCH {
 		extractMergePatchRV(obj, patch, &preconditions)
 	}
-	return c.handleEffect(ctx, obj, op, &preconditions, nil)
+	options := &EffectOptions{PatchType: patch.Type()}
+	if op != event.APPLY {
+		return c.handleEffect(ctx, obj, op, &preconditions, options)
+	}
+	applyObj, err := patchToUnstructured(obj, patch)
+	if err != nil {
+		return err
+	}
+	if err := c.handleEffect(ctx, applyObj, op, &preconditions, options); err != nil {
+		return err
+	}
+	return c.copyInto(obj, applyObj)
 }
 
 // Apply models server-side apply operations introduced in controller-runtime v0.22+.
@@ -420,27 +443,46 @@ func applyConfigToUnstructured(obj runtime.ApplyConfiguration) (*unstructured.Un
 		}
 	}
 
-	// Fall back to the typed apply configuration interface.
-	ac, ok := obj.(interface {
-		GetName() *string
-		GetNamespace() *string
-		GetKind() *string
-		GetAPIVersion() *string
-	})
-	if !ok {
-		return nil, fmt.Errorf("%T is a runtime.ApplyConfiguration but not an applyConfiguration", obj)
+	data, err := json.Marshal(obj)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling %T apply configuration: %w", obj, err)
 	}
-
 	u := &unstructured.Unstructured{}
-	if name := ptr.Deref(ac.GetName(), ""); name != "" {
-		u.SetName(name)
+	if err := json.Unmarshal(data, &u.Object); err != nil {
+		return nil, fmt.Errorf("decoding %T apply configuration: %w", obj, err)
 	}
-	if ns := ptr.Deref(ac.GetNamespace(), ""); ns != "" {
-		u.SetNamespace(ns)
-	}
-	u.SetKind(ptr.Deref(ac.GetKind(), ""))
-	u.SetAPIVersion(ptr.Deref(ac.GetAPIVersion(), ""))
 	return u, nil
+}
+
+func patchToUnstructured(obj client.Object, patch client.Patch) (*unstructured.Unstructured, error) {
+	data, err := patch.Data(obj)
+	if err != nil {
+		return nil, fmt.Errorf("building %s patch: %w", patch.Type(), err)
+	}
+	intent := &unstructured.Unstructured{}
+	if err := json.Unmarshal(data, &intent.Object); err != nil {
+		jsonData, yamlErr := yaml.YAMLToJSON(data)
+		if yamlErr != nil {
+			return nil, fmt.Errorf("decoding %s patch: %w", patch.Type(), err)
+		}
+		if jsonErr := json.Unmarshal(jsonData, &intent.Object); jsonErr != nil {
+			return nil, fmt.Errorf("decoding %s patch: %w", patch.Type(), jsonErr)
+		}
+	}
+	gvk := util.GetGroupVersionKind(obj)
+	if intent.GetAPIVersion() == "" {
+		intent.SetAPIVersion(gvk.GroupVersion().String())
+	}
+	if intent.GetKind() == "" {
+		intent.SetKind(gvk.Kind)
+	}
+	if intent.GetName() == "" {
+		intent.SetName(obj.GetName())
+	}
+	if intent.GetNamespace() == "" {
+		intent.SetNamespace(obj.GetNamespace())
+	}
+	return intent, nil
 }
 
 func (c *Client) Status() client.SubResourceWriter {
@@ -468,7 +510,18 @@ func (c *subResourceClient) Patch(ctx context.Context, obj client.Object, patch 
 	if op == event.PATCH {
 		extractMergePatchRV(obj, patch, &preconditions)
 	}
-	return c.wrapped.handleEffect(ctx, obj, op, &preconditions, &EffectOptions{Subresource: "status"})
+	options := &EffectOptions{Subresource: "status", PatchType: patch.Type()}
+	if op != event.APPLY {
+		return c.wrapped.handleEffect(ctx, obj, op, &preconditions, options)
+	}
+	applyObj, err := patchToUnstructured(obj, patch)
+	if err != nil {
+		return err
+	}
+	if err := c.wrapped.handleEffect(ctx, applyObj, op, &preconditions, options); err != nil {
+		return err
+	}
+	return c.wrapped.copyInto(obj, applyObj)
 }
 
 func (c *subResourceClient) Create(ctx context.Context, obj client.Object, sub client.Object, opts ...client.SubResourceCreateOption) error {
@@ -477,9 +530,10 @@ func (c *subResourceClient) Create(ctx context.Context, obj client.Object, sub c
 }
 
 func (c *subResourceClient) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...client.SubResourceApplyOption) error {
+	preconditions := ExtractStatusApplyPreconditions(opts)
 	u, err := applyConfigToUnstructured(obj)
 	if err != nil {
 		return err
 	}
-	return c.wrapped.handleEffect(ctx, u, event.APPLY, nil, &EffectOptions{Subresource: "status"})
+	return c.wrapped.handleEffect(ctx, u, event.APPLY, &preconditions, &EffectOptions{Subresource: "status", PatchType: types.ApplyPatchType})
 }

--- a/pkg/replay/client_test.go
+++ b/pkg/replay/client_test.go
@@ -12,19 +12,22 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
+	applycorev1 "k8s.io/client-go/applyconfigurations/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type recordingRecorder struct {
-	opType  event.OperationType
-	obj     client.Object
-	options *EffectOptions
+	opType        event.OperationType
+	obj           client.Object
+	options       *EffectOptions
+	preconditions *PreconditionInfo
 }
 
-func (r *recordingRecorder) RecordEffect(_ context.Context, obj client.Object, opType event.OperationType, _ *PreconditionInfo, options *EffectOptions) error {
+func (r *recordingRecorder) RecordEffect(_ context.Context, obj client.Object, opType event.OperationType, preconditions *PreconditionInfo, options *EffectOptions) error {
 	r.opType = opType
 	r.obj = obj.DeepCopyObject().(client.Object)
 	r.options = options
+	r.preconditions = preconditions
 	return nil
 }
 
@@ -43,10 +46,56 @@ func TestClientPatchApplyUsesApplyOp(t *testing.T) {
 	obj.SetKind("ConfigMap")
 	obj.SetNamespace("default")
 	obj.SetName("example")
+	obj.Object["data"] = map[string]interface{}{"key": "value"}
 
-	err := c.Patch(context.Background(), obj, client.Apply)
+	err := c.Patch(context.Background(), obj, client.Apply, client.FieldOwner("test-manager"), client.ForceOwnership)
 	assert.NoError(t, err)
 	assert.Equal(t, event.APPLY, recorder.opType)
+	require.Equal(t, map[string]interface{}{"key": "value"}, recorder.obj.(*unstructured.Unstructured).Object["data"])
+	require.NotNil(t, recorder.preconditions)
+	assert.Equal(t, "test-manager", recorder.preconditions.FieldManager)
+	assert.True(t, recorder.preconditions.Force)
+	require.NotNil(t, recorder.options)
+	assert.Equal(t, types.ApplyPatchType, recorder.options.PatchType)
+}
+
+func TestClientTypedApplyPreservesCompleteConfiguration(t *testing.T) {
+	recorder := &recordingRecorder{}
+	c := NewClient("test", nil, noopFrameReader{}, recorder)
+	configuration := applycorev1.ConfigMap("example", "default").WithData(map[string]string{"key": "value"})
+
+	err := c.Apply(context.Background(), configuration, client.FieldOwner("typed-manager"))
+	require.NoError(t, err)
+	require.Equal(t, event.APPLY, recorder.opType)
+	applyObj := recorder.obj.(*unstructured.Unstructured)
+	require.Equal(t, "value", applyObj.Object["data"].(map[string]interface{})["key"])
+	require.NotNil(t, recorder.preconditions)
+	require.Equal(t, "typed-manager", recorder.preconditions.FieldManager)
+}
+
+func TestClientRawYAMLApplyPreservesPatchBody(t *testing.T) {
+	recorder := &recordingRecorder{}
+	c := NewClient("test", nil, noopFrameReader{}, recorder)
+	target := &unstructured.Unstructured{}
+	target.SetAPIVersion("v1")
+	target.SetKind("ConfigMap")
+	target.SetNamespace("default")
+	target.SetName("example")
+	patch := client.RawPatch(types.ApplyPatchType, []byte(`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example
+  namespace: default
+data:
+  key: value
+`))
+
+	err := c.Patch(context.Background(), target, patch, client.FieldOwner("raw-manager"))
+	require.NoError(t, err)
+	applyObj := recorder.obj.(*unstructured.Unstructured)
+	require.Equal(t, "value", applyObj.Object["data"].(map[string]interface{})["key"])
+	require.Equal(t, "raw-manager", recorder.preconditions.FieldManager)
 }
 
 func TestClientStatusPatchApplyUsesApplyOp(t *testing.T) {

--- a/pkg/replay/effects.go
+++ b/pkg/replay/effects.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/tgoodwin/kamera/pkg/event"
 	"github.com/tgoodwin/kamera/pkg/util"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -15,7 +16,9 @@ type EffectRecorder interface {
 }
 
 type EffectOptions struct {
-	Subresource string
+	Subresource  string
+	PatchType    types.PatchType
+	ReconcilerID string
 }
 
 type DataEffect struct {

--- a/pkg/replay/preconditions.go
+++ b/pkg/replay/preconditions.go
@@ -3,6 +3,7 @@ package replay
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -33,6 +34,9 @@ type PreconditionInfo struct {
 	ResourceVersion *string    // For optimistic concurrency control
 	UID             *types.UID // For delete operations with UID check
 	DryRun          bool       // For operations that shouldn't affect state
+	FieldManager    string
+	Force           bool
+	FieldValidation string
 }
 
 // ExtractCreatePreconditions extracts preconditions from CreateOptions
@@ -43,7 +47,9 @@ func ExtractCreatePreconditions(opts []client.CreateOption) PreconditionInfo {
 	}
 
 	return PreconditionInfo{
-		DryRun: containsDryRun(createOpts.DryRun),
+		DryRun:          containsDryRun(createOpts.DryRun),
+		FieldManager:    createOpts.FieldManager,
+		FieldValidation: createOpts.FieldValidation,
 	}
 }
 
@@ -55,7 +61,9 @@ func ExtractUpdatePreconditions(opts []client.UpdateOption) PreconditionInfo {
 	}
 
 	return PreconditionInfo{
-		DryRun: containsDryRun(updateOpts.DryRun),
+		DryRun:          containsDryRun(updateOpts.DryRun),
+		FieldManager:    updateOpts.FieldManager,
+		FieldValidation: updateOpts.FieldValidation,
 	}
 }
 
@@ -90,9 +98,11 @@ func ExtractPatchPreconditions(opts []client.PatchOption) PreconditionInfo {
 		opt.ApplyToPatch(patchOpts)
 	}
 
-	// Patches can specify Force conflict resolution
 	return PreconditionInfo{
-		DryRun: containsDryRun(patchOpts.DryRun),
+		DryRun:          containsDryRun(patchOpts.DryRun),
+		FieldManager:    patchOpts.FieldManager,
+		Force:           ptr.Deref(patchOpts.Force, false),
+		FieldValidation: patchOpts.FieldValidation,
 	}
 }
 
@@ -104,7 +114,9 @@ func ExtractApplyPreconditions(opts []client.ApplyOption) PreconditionInfo {
 	}
 
 	return PreconditionInfo{
-		DryRun: containsDryRun(applyOpts.DryRun),
+		DryRun:       containsDryRun(applyOpts.DryRun),
+		FieldManager: applyOpts.FieldManager,
+		Force:        ptr.Deref(applyOpts.Force, false),
 	}
 }
 
@@ -135,7 +147,9 @@ func ExtractStatusUpdatePreconditions(opts []client.SubResourceUpdateOption) Pre
 	}
 
 	return PreconditionInfo{
-		DryRun: containsDryRun(updateOpts.DryRun),
+		DryRun:          containsDryRun(updateOpts.DryRun),
+		FieldManager:    updateOpts.FieldManager,
+		FieldValidation: updateOpts.FieldValidation,
 	}
 }
 
@@ -147,7 +161,10 @@ func ExtractStatusPatchPreconditions(opts []client.SubResourcePatchOption) Preco
 	}
 
 	return PreconditionInfo{
-		DryRun: containsDryRun(patchOpts.DryRun),
+		DryRun:          containsDryRun(patchOpts.DryRun),
+		FieldManager:    patchOpts.FieldManager,
+		Force:           ptr.Deref(patchOpts.Force, false),
+		FieldValidation: patchOpts.FieldValidation,
 	}
 }
 
@@ -159,7 +176,24 @@ func ExtractSubResourceCreatePreconditions(opts []client.SubResourceCreateOption
 	}
 
 	return PreconditionInfo{
-		DryRun: containsDryRun(createOpts.DryRun),
+		DryRun:          containsDryRun(createOpts.DryRun),
+		FieldManager:    createOpts.FieldManager,
+		FieldValidation: createOpts.FieldValidation,
+	}
+}
+
+// ExtractStatusApplyPreconditions extracts preconditions from
+// SubResourceApplyOptions.
+func ExtractStatusApplyPreconditions(opts []client.SubResourceApplyOption) PreconditionInfo {
+	applyOpts := &client.SubResourceApplyOptions{}
+	for _, opt := range opts {
+		opt.ApplyToSubResourceApply(applyOpts)
+	}
+
+	return PreconditionInfo{
+		DryRun:       containsDryRun(applyOpts.DryRun),
+		FieldManager: applyOpts.FieldManager,
+		Force:        ptr.Deref(applyOpts.Force, false),
 	}
 }
 

--- a/pkg/tracecheck/explore.go
+++ b/pkg/tracecheck/explore.go
@@ -49,7 +49,7 @@ type StalenessInterval struct {
 	StaleAt         int64        `json:"staleAt"`
 	CatchUpAt       int64        `json:"catchUpAt"`
 	Lag             int64        `json:"lag"`             // how far behind frontier; -1 = frozen
-	FreezeAtSequence int64       `json:"freezeAt,omitempty"` // when lag=-1 and set, freeze at this sequence instead of staleAt
+	FreezeAtSequence int64        `json:"freezeAt,omitempty"` // when lag=-1 and set, freeze at this sequence instead of staleAt
 }
 
 // PermuteDepthRange constrains ordering permutations to a specific depth window.
@@ -1682,6 +1682,30 @@ func (e *Explorer) applyEffects(stepLogger logr.Logger, stateView StateNode, ste
 	for _, effect := range stepResult.Changes.Effects {
 		existingKey, exists := nextState.HasNamespacedNameForKind(effect.Key.ResourceKey)
 
+		if effect.Materialized {
+			switch effect.OpType {
+			case event.CREATE:
+				if exists {
+					panic("materialized create effect object already exists: " + effect.Key.String())
+				}
+			case event.UPDATE, event.APPLY:
+				if effect.OpType == event.UPDATE && !exists {
+					panic("materialized update effect object not found: " + effect.Key.String())
+				}
+			default:
+				panic(fmt.Sprintf("unsupported materialized effect type: %s", effect.OpType))
+			}
+			if exists && nextState[existingKey] == effect.Version {
+				continue
+			}
+			if exists && existingKey != effect.Key {
+				delete(nextState, existingKey)
+			}
+			changes[effect.Key] = effect.Version
+			nextState[effect.Key] = effect.Version
+			goto recordMaterializedEffect
+		}
+
 		switch effect.OpType {
 		case event.CREATE:
 			if exists {
@@ -1883,6 +1907,7 @@ func (e *Explorer) applyEffects(stepLogger logr.Logger, stateView StateNode, ste
 			panic(fmt.Errorf("unknown effect type: %s", effect.OpType))
 		}
 
+	recordMaterializedEffect:
 		highestSequence++
 		newRV := highestSequence
 

--- a/pkg/tracecheck/explorebuilder.go
+++ b/pkg/tracecheck/explorebuilder.go
@@ -1,12 +1,14 @@
 package tracecheck
 
 import (
+	"errors"
 	"fmt"
 	"maps"
 	"slices"
 	"time"
 
 	"github.com/samber/lo"
+	"github.com/tgoodwin/kamera/pkg/apiserver"
 	"github.com/tgoodwin/kamera/pkg/event"
 	"github.com/tgoodwin/kamera/pkg/replay"
 	"github.com/tgoodwin/kamera/pkg/snapshot"
@@ -14,11 +16,13 @@ import (
 	"github.com/tgoodwin/kamera/sleevectrl/pkg/controller"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/kube-openapi/pkg/spec3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -56,6 +60,10 @@ type ExplorerBuilder struct {
 	// Owned by the builder so it is available during BuildStartStateFromObjects
 	// (before Build) and then transferred to the Explorer in Build().
 	resourceVersions map[snapshot.VersionHash]int64
+
+	schemaRegistry *apiserver.Registry
+	requireSchemas bool
+	schemaErrors   []error
 
 	// onForkFuncs are called at the beginning of Fork() to reset shared
 	// mutable state that lives outside the snapshot system (e.g. in-memory
@@ -130,6 +138,7 @@ func NewExplorerBuilder(scheme *runtime.Scheme) *ExplorerBuilder {
 		snapStore:                  snapshot.NewStore(),
 		reconcilerToKind:           make(map[ReconcilerID]string),
 		resourceVersions:           make(map[snapshot.VersionHash]int64),
+		schemaRegistry:             apiserver.NewRegistry(),
 
 		config: &ExploreConfig{
 			MaxDepth:        *searchDepth,
@@ -151,6 +160,45 @@ func NewExplorerBuilder(scheme *runtime.Scheme) *ExplorerBuilder {
 	builder.registerCoreControllers()
 
 	return builder
+}
+
+// RequireSchemas makes schema registration mandatory for every API write that
+// needs type topology. Reads and deletes do not require a schema.
+func (b *ExplorerBuilder) RequireSchemas() *ExplorerBuilder {
+	b.requireSchemas = true
+	return b
+}
+
+// WithCRD registers all served structural schemas declared by a CRD.
+func (b *ExplorerBuilder) WithCRD(crd *apiextensionsv1.CustomResourceDefinition) *ExplorerBuilder {
+	if err := b.schemaRegistry.RegisterCRD(crd); err != nil {
+		b.schemaErrors = append(b.schemaErrors, err)
+	}
+	return b
+}
+
+// WithResourceSchema registers one GVK from a structural OpenAPI v3 schema.
+// This is the explicit registration path for built-in and aggregated APIs.
+func (b *ExplorerBuilder) WithResourceSchema(
+	gvk schema.GroupVersionKind,
+	namespaced bool,
+	hasStatus bool,
+	openAPIV3Schema *apiextensionsv1.JSONSchemaProps,
+) *ExplorerBuilder {
+	if err := b.schemaRegistry.RegisterResourceSchema(gvk, namespaced, hasStatus, openAPIV3Schema); err != nil {
+		b.schemaErrors = append(b.schemaErrors, err)
+	}
+	return b
+}
+
+// WithOpenAPIV3 registers GVK schemas from a complete OpenAPI v3 document.
+// OpenAPI does not describe resource scope or status-subresource availability;
+// use WithCRD or WithResourceSchema when those semantics matter.
+func (b *ExplorerBuilder) WithOpenAPIV3(doc *spec3.OpenAPI) *ExplorerBuilder {
+	if err := b.schemaRegistry.RegisterOpenAPIV3(doc); err != nil {
+		b.schemaErrors = append(b.schemaErrors, err)
+	}
+	return b
 }
 
 // BuildRestartSeed materializes the provided state into a restart seed using the builder's store.
@@ -210,6 +258,9 @@ func (b *ExplorerBuilder) Fork() *ExplorerBuilder {
 		podCrashProbabilities:      maps.Clone(b.podCrashProbabilities),
 		userActions:                slices.Clone(b.userActions),
 		resourceVersions:           make(map[snapshot.VersionHash]int64),
+		schemaRegistry:             b.schemaRegistry.Clone(),
+		requireSchemas:             b.requireSchemas,
+		schemaErrors:               slices.Clone(b.schemaErrors),
 		onForkFuncs:                b.onForkFuncs,
 		onCrashFuncs:               b.onCrashFuncs,
 	}
@@ -800,7 +851,11 @@ func (b *ExplorerBuilder) instantiateCleanupReconciler(mgr *manager) *Reconciler
 }
 
 func (b *ExplorerBuilder) NewStateEventBuilder() *StateEventBuilder {
-	return NewStateEventBuilder(b.snapStore, b.scheme)
+	builder := NewStateEventBuilder(b.snapStore, b.scheme)
+	builder.prepareInitial = func(obj client.Object) error {
+		return b.seedInitialFieldOwnership([]client.Object{obj})
+	}
+	return builder
 }
 
 func (b *ExplorerBuilder) NewStateClassifier() *StateClassifier {
@@ -878,6 +933,12 @@ func (b *ExplorerBuilder) PrimeVersionStoreFromHistory(history ExecutionHistory,
 
 // BuildStartStateFromObjects constructs a starting StateNode from concrete objects and an initial pending list.
 func (b *ExplorerBuilder) BuildStartStateFromObjects(objs []client.Object, pending []PendingReconcile) (StateNode, error) {
+	if err := errors.Join(b.schemaErrors...); err != nil {
+		return StateNode{}, fmt.Errorf("registering API schemas: %w", err)
+	}
+	if err := b.seedInitialFieldOwnership(objs); err != nil {
+		return StateNode{}, err
+	}
 	return buildStartStateFromObjects(b.snapStore, b.scheme, objs, pending, b.resourceVersions)
 }
 
@@ -915,6 +976,9 @@ func (b *ExplorerBuilder) GetStartStateFromObject(obj client.Object, dependentCo
 }
 
 func (b *ExplorerBuilder) Build(modes ...string) (*Explorer, error) {
+	if err := errors.Join(b.schemaErrors...); err != nil {
+		return nil, fmt.Errorf("registering API schemas: %w", err)
+	}
 	// TODO just pull out a dedicated 'BuildFromTraceFile' type of thing
 	// to keep that concept separate.
 	mode := "standalone"
@@ -961,7 +1025,12 @@ func (b *ExplorerBuilder) Build(modes ...string) (*Explorer, error) {
 
 		// effectRVs tracks the current integer resourceVersion per resource key
 		// per frame, for optimistic concurrency conflict checking.
-		effectRVs: make(map[string]map[string]int64),
+		effectRVs:     make(map[string]map[string]int64),
+		effectObjects: make(map[string]map[string]*unstructured.Unstructured),
+		effectNextRV:  make(map[string]int64),
+
+		schemaRegistry: b.schemaRegistry,
+		requireSchemas: b.requireSchemas,
 	}
 
 	// Initialize reconcilers with appropriate clients
@@ -1031,12 +1100,16 @@ func (b *ExplorerBuilder) BuildLensManager(traceFilePath string) (*LensManager, 
 	}
 	rollup := CausalRollup(traces)
 	mgr := &manager{
-		versionStore: NewVersionStore(b.snapStore, b.scheme),
-		effects:      make(map[string]reconcileEffects),
-		scheme:       b.scheme,
-		effectRKeys:  make(map[string]util.Set[string]),
-		effectIKeys:  make(map[string]util.Set[snapshot.IdentityKey]),
-		effectRVs:    make(map[string]map[string]int64),
+		versionStore:   NewVersionStore(b.snapStore, b.scheme),
+		effects:        make(map[string]reconcileEffects),
+		scheme:         b.scheme,
+		effectRKeys:    make(map[string]util.Set[string]),
+		effectIKeys:    make(map[string]util.Set[snapshot.IdentityKey]),
+		effectRVs:      make(map[string]map[string]int64),
+		effectObjects:  make(map[string]map[string]*unstructured.Unstructured),
+		effectNextRV:   make(map[string]int64),
+		schemaRegistry: b.schemaRegistry,
+		requireSchemas: b.requireSchemas,
 	}
 
 	return NewLensManager(

--- a/pkg/tracecheck/manager.go
+++ b/pkg/tracecheck/manager.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/samber/lo"
+	"github.com/tgoodwin/kamera/pkg/apiserver"
 	"github.com/tgoodwin/kamera/pkg/event"
 	"github.com/tgoodwin/kamera/pkg/replay"
 	"github.com/tgoodwin/kamera/pkg/snapshot"
@@ -31,10 +32,11 @@ type VersionManager interface {
 }
 
 type Effect struct {
-	OpType      event.OperationType
-	Key         snapshot.CompositeKey
-	Version     snapshot.VersionHash
-	Subresource string `json:"subresource,omitempty"`
+	OpType       event.OperationType
+	Key          snapshot.CompositeKey
+	Version      snapshot.VersionHash
+	Subresource  string `json:"subresource,omitempty"`
+	Materialized bool   `json:"materialized,omitempty"`
 
 	Precondition *replay.PreconditionInfo
 }
@@ -87,6 +89,15 @@ type manager struct {
 	// frameID → resourceKey → current integer RV
 	effectRVs map[string]map[string]int64
 
+	// effectObjects is the synchronous API-server view for a reconcile frame.
+	// Unlike the cache frame, it advances after each successful write.
+	effectObjects  map[string]map[string]*unstructured.Unstructured
+	effectNextRV   map[string]int64
+	effectVersions map[string]map[string]snapshot.VersionHash
+
+	schemaRegistry *apiserver.Registry
+	requireSchemas bool
+
 	// rvLookup maps VersionHash → integer resourceVersion.
 	// Set from the explorer's resourceVersions map.
 	rvLookup func(snapshot.VersionHash) int64
@@ -127,9 +138,26 @@ func (m *manager) RecordEffect(ctx context.Context, obj client.Object, opType ev
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	// this will insert a resourceKey into the resourceValidator store
-	if err := m.validateEffect(ctx, opType, obj, precondition, options); err != nil {
-		return err
+	materialized := false
+	materializedChanged := false
+	materializedKey := ""
+	if event.IsWriteOp(opType) && opType != event.MARK_FOR_DELETION && opType != event.REMOVE {
+		var err error
+		obj, materialized, materializedChanged, materializedKey, err = m.materializeSchemaWrite(ctx, obj, opType, precondition, options)
+		if err != nil {
+			return err
+		}
+		if precondition != nil && precondition.DryRun && materialized {
+			return nil
+		}
+	}
+
+	// Schema-backed writes were validated against the synchronous object view
+	// while being materialized. Legacy effects retain the existing validator.
+	if !materialized {
+		if err := m.validateEffect(ctx, opType, obj, precondition, options); err != nil {
+			return err
+		}
 	}
 
 	gvk := ensureObjectGVK(obj, m.scheme)
@@ -145,13 +173,33 @@ func (m *manager) RecordEffect(ctx context.Context, obj client.Object, opType ev
 	}
 
 	frameID := replay.FrameIDFromContext(ctx)
-	u, err := util.ConvertToUnstructured(obj)
+	var u *unstructured.Unstructured
+	var err error
+	if materialized {
+		u, err = schemaResponseToUnstructured(obj, gvk)
+	} else {
+		u, err = util.ConvertToUnstructured(obj)
+	}
 	if err != nil {
 		return err
 	}
 
-	// publish the object versionHash
-	versionHash := m.Publish(u)
+	// A successful no-op returns the current version. Publishing the response
+	// would create a different hash when its served resourceVersion was stamped
+	// from frame bookkeeping rather than stored object metadata.
+	var versionHash snapshot.VersionHash
+	if materialized && !materializedChanged {
+		var found bool
+		versionHash, found = m.effectVersions[frameID][materializedKey]
+		if !found {
+			return fmt.Errorf("schema-backed no-op has no live version for %s", materializedKey)
+		}
+	} else {
+		versionHash = m.Publish(u)
+	}
+	if materialized {
+		m.effectVersions[frameID][materializedKey] = versionHash
+	}
 
 	reffects, ok := m.effects[frameID]
 	if !ok {
@@ -163,6 +211,7 @@ func (m *manager) RecordEffect(ctx context.Context, obj client.Object, opType ev
 
 	key := snapshot.NewCompositeKeyWithGroup(gvk.Group, kind, obj.GetNamespace(), obj.GetName(), sleeveObjectID)
 	eff := newEffectWithOptions(key, versionHash, opType, precondition, options)
+	eff.Materialized = materialized
 	if opType == event.GET || opType == event.LIST {
 		reffects.reads = append(reffects.reads, eff)
 	} else {
@@ -182,6 +231,15 @@ func (m *manager) RecordEffect(ctx context.Context, obj client.Object, opType ev
 
 func (m *manager) PrepareEffectContext(ctx context.Context, ov ObjectVersions) error {
 	frameID := replay.FrameIDFromContext(ctx)
+	if m.effectObjects == nil {
+		m.effectObjects = make(map[string]map[string]*unstructured.Unstructured)
+	}
+	if m.effectNextRV == nil {
+		m.effectNextRV = make(map[string]int64)
+	}
+	if m.effectVersions == nil {
+		m.effectVersions = make(map[string]map[string]snapshot.VersionHash)
+	}
 	cKeys := lo.Keys(ov)
 	// holds objectID
 	iKeys := lo.Map(cKeys, func(k snapshot.CompositeKey, _ int) snapshot.IdentityKey {
@@ -191,19 +249,36 @@ func (m *manager) PrepareEffectContext(ctx context.Context, ov ObjectVersions) e
 	// holds kind/namespace/name
 	rKeySet := util.NewSet[string]()
 	rvs := make(map[string]int64, len(ov))
+	objects := make(map[string]*unstructured.Unstructured, len(ov))
+	versions := make(map[string]snapshot.VersionHash, len(ov))
+	var highestRV int64
 	for ck, vh := range ov {
 		primary := canonicalResourceKeyString(ck.ResourceKey.Group, ck.ResourceKey.Kind, ck.ResourceKey.Namespace, ck.ResourceKey.Name)
 		rKeySet.Add(primary)
+		versions[primary] = vh
 		// Look up the integer RV for this object version
 		if m.rvLookup != nil {
 			if rv := m.rvLookup(vh); rv > 0 {
 				rvs[primary] = rv
+				if rv > highestRV {
+					highestRV = rv
+				}
 			}
+		}
+		if obj := m.Resolve(vh); obj != nil {
+			copy := obj.DeepCopy()
+			if rv := rvs[primary]; rv > 0 {
+				copy.SetResourceVersion(strconv.FormatInt(rv, 10))
+			}
+			objects[primary] = copy
 		}
 	}
 	m.effectRKeys[frameID] = rKeySet
 	m.effectIKeys[frameID] = util.NewSet(iKeys...)
 	m.effectRVs[frameID] = rvs
+	m.effectObjects[frameID] = objects
+	m.effectNextRV[frameID] = highestRV
+	m.effectVersions[frameID] = versions
 	return nil
 }
 
@@ -212,6 +287,9 @@ func (m *manager) CleanupEffectContext(ctx context.Context) {
 	delete(m.effectRKeys, frameID)
 	delete(m.effectIKeys, frameID)
 	delete(m.effectRVs, frameID)
+	delete(m.effectObjects, frameID)
+	delete(m.effectNextRV, frameID)
+	delete(m.effectVersions, frameID)
 }
 
 func (m *manager) GetEffects(ctx context.Context) (Changes, error) {

--- a/pkg/tracecheck/schema_initial_state.go
+++ b/pkg/tracecheck/schema_initial_state.go
@@ -1,0 +1,70 @@
+package tracecheck
+
+import (
+	"fmt"
+
+	"github.com/tgoodwin/kamera/pkg/tag"
+	"github.com/tgoodwin/kamera/pkg/util"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const initialFieldManager = "kamera-initial-state"
+
+func (b *ExplorerBuilder) seedInitialFieldOwnership(objs []client.Object) error {
+	// Identity must exist before ownerReference validation and ownership seeding.
+	for idx, obj := range objs {
+		if obj == nil {
+			return fmt.Errorf("initial object %d is nil", idx)
+		}
+		tag.EnsureDeterministicIdentity(obj)
+		ensureObjectGVK(obj, b.scheme)
+	}
+	fixupOwnerReferenceUIDs(objs)
+
+	for idx, obj := range objs {
+		gvk := ensureObjectGVK(obj, b.scheme)
+		resourceSchema, registered := b.schemaRegistry.Lookup(gvk)
+		if !registered {
+			if b.requireSchemas {
+				return fmt.Errorf("initial object %d requires a registered schema for %s", idx, gvk)
+			}
+			continue
+		}
+		if len(obj.GetManagedFields()) > 0 {
+			continue
+		}
+
+		desired, err := util.ConvertToUnstructured(obj)
+		if err != nil {
+			return fmt.Errorf("converting initial object %d: %w", idx, err)
+		}
+		desired.SetGroupVersionKind(gvk)
+		created, err := resourceSchema.Create(desired, initialFieldManager)
+		if err != nil {
+			return fmt.Errorf("seeding field ownership for initial %s %s/%s: %w", gvk, obj.GetNamespace(), obj.GetName(), err)
+		}
+
+		if resourceSchema.HasStatus {
+			if status, found := desired.Object["status"]; found {
+				statusIntent := &unstructured.Unstructured{Object: map[string]interface{}{
+					"apiVersion": gvk.GroupVersion().String(),
+					"kind":       gvk.Kind,
+					"metadata": map[string]interface{}{
+						"name":      desired.GetName(),
+						"namespace": desired.GetNamespace(),
+					},
+					"status": status,
+				}}
+				created, err = resourceSchema.Apply(created, statusIntent, initialFieldManager+"-status", true, "status")
+				if err != nil {
+					return fmt.Errorf("seeding status ownership for initial %s %s/%s: %w", gvk, obj.GetNamespace(), obj.GetName(), err)
+				}
+			}
+		}
+		if err := copyUnstructuredInto(obj, created, b.scheme); err != nil {
+			return fmt.Errorf("copying initial schema-backed object %d: %w", idx, err)
+		}
+	}
+	return nil
+}

--- a/pkg/tracecheck/schema_writes.go
+++ b/pkg/tracecheck/schema_writes.go
@@ -1,0 +1,164 @@
+package tracecheck
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/tgoodwin/kamera/pkg/event"
+	"github.com/tgoodwin/kamera/pkg/replay"
+	"github.com/tgoodwin/kamera/pkg/snapshot"
+	"github.com/tgoodwin/kamera/pkg/tag"
+	"github.com/tgoodwin/kamera/pkg/util"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// materializeSchemaWrite applies API-server semantics before the effect is
+// published. The returned bool distinguishes exact, schema-backed effects from
+// legacy effects that apply their approximation later in Explorer.applyEffects.
+func (m *manager) materializeSchemaWrite(
+	ctx context.Context,
+	obj client.Object,
+	op event.OperationType,
+	precondition *replay.PreconditionInfo,
+	options *replay.EffectOptions,
+) (client.Object, bool, bool, string, error) {
+	if obj == nil {
+		return obj, false, false, "", apierrors.NewBadRequest("write object is nil")
+	}
+	gvk := ensureObjectGVK(obj, m.scheme)
+	resourceSchema, registered := m.schemaRegistry.Lookup(gvk)
+	if !registered {
+		if m.requireSchemas {
+			reconcilerID := "unknown"
+			if options != nil && options.ReconcilerID != "" {
+				reconcilerID = options.ReconcilerID
+			}
+			return obj, false, false, "", fmt.Errorf(
+				"schema-backed %s by reconciler %q requires a registered schema for %s; register it with WithCRD, WithResourceSchema, or WithOpenAPIV3",
+				op, reconcilerID, gvk,
+			)
+		}
+		return obj, false, false, "", nil
+	}
+
+	// Non-apply patch payload materialization remains on the legacy path. SSA
+	// patches arrive as APPLY and are handled below.
+	if op == event.PATCH {
+		return obj, false, false, "", nil
+	}
+
+	intent, err := util.ConvertToUnstructured(obj)
+	if err != nil {
+		return obj, false, false, "", err
+	}
+	intent.SetGroupVersionKind(gvk)
+	frameID := replay.FrameIDFromContext(ctx)
+	primary := canonicalResourceKeyString(gvk.Group, gvk.Kind, intent.GetNamespace(), intent.GetName())
+	live := m.effectObjects[frameID][primary]
+	subresource := ""
+	if options != nil {
+		subresource = options.Subresource
+	}
+	manager := ""
+	force := false
+	if precondition != nil {
+		manager = precondition.FieldManager
+		force = precondition.Force
+	}
+
+	var result *unstructured.Unstructured
+	switch op {
+	case event.CREATE:
+		if live != nil {
+			return obj, false, false, primary, apierrors.NewAlreadyExists(
+				schema.GroupResource{Group: gvk.Group, Resource: gvk.Kind}, intent.GetName())
+		}
+		result, err = resourceSchema.Create(intent, manager)
+	case event.UPDATE:
+		result, err = resourceSchema.Update(live, intent, manager, subresource)
+	case event.APPLY:
+		if subresource == "status" && live == nil {
+			return obj, false, false, primary, apierrors.NewNotFound(
+				schema.GroupResource{Group: gvk.Group, Resource: gvk.Kind}, intent.GetName())
+		}
+		result, err = resourceSchema.Apply(live, intent, manager, force, subresource)
+	default:
+		return obj, false, false, "", nil
+	}
+	if err != nil {
+		return obj, false, false, primary, err
+	}
+
+	rKeyExisted := m.effectRKeys[frameID].Contains(primary)
+	if err := m.validateEffect(ctx, op, result, precondition, options); err != nil {
+		return obj, false, false, primary, err
+	}
+	if precondition != nil && precondition.DryRun {
+		if !rKeyExisted {
+			m.effectRKeys[frameID].Delete(primary)
+		}
+		if err := copyUnstructuredInto(obj, result, m.scheme); err != nil {
+			return obj, false, false, primary, fmt.Errorf("copying schema-backed dry-run response into %T: %w", obj, err)
+		}
+		return obj, true, false, primary, nil
+	}
+
+	changed := live == nil || !sameUnstructuredJSON(live, result)
+	if changed {
+		m.effectNextRV[frameID]++
+		result.SetResourceVersion(strconv.FormatInt(m.effectNextRV[frameID], 10))
+		m.effectRVs[frameID][primary] = m.effectNextRV[frameID]
+	} else if live != nil {
+		result.SetResourceVersion(live.GetResourceVersion())
+	}
+	m.effectObjects[frameID][primary] = result.DeepCopy()
+	if live == nil {
+		m.effectIKeys[frameID].Add(snapshot.IdentityKey{
+			Group: gvk.Group, Kind: gvk.Kind, ObjectID: tag.GetSleeveObjectID(result),
+		})
+	}
+
+	if err := copyUnstructuredInto(obj, result, m.scheme); err != nil {
+		return obj, false, false, primary, fmt.Errorf("copying schema-backed response into %T: %w", obj, err)
+	}
+	return obj, true, changed, primary, nil
+}
+
+func sameUnstructuredJSON(left, right *unstructured.Unstructured) bool {
+	leftJSON, leftErr := json.Marshal(left.Object)
+	rightJSON, rightErr := json.Marshal(right.Object)
+	return leftErr == nil && rightErr == nil && bytes.Equal(leftJSON, rightJSON)
+}
+
+func copyUnstructuredInto(obj client.Object, from *unstructured.Unstructured, scheme *runtime.Scheme) error {
+	if unstr, ok := obj.(runtime.Unstructured); ok {
+		unstr.SetUnstructuredContent(from.DeepCopy().Object)
+		return nil
+	}
+	if scheme != nil {
+		if err := scheme.Convert(from, obj, nil); err == nil {
+			return nil
+		}
+	}
+	return runtime.DefaultUnstructuredConverter.FromUnstructured(from.Object, obj)
+}
+
+func schemaResponseToUnstructured(obj client.Object, gvk schema.GroupVersionKind) (*unstructured.Unstructured, error) {
+	if existing, ok := obj.(*unstructured.Unstructured); ok {
+		return existing.DeepCopy(), nil
+	}
+	raw, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return nil, err
+	}
+	result := &unstructured.Unstructured{Object: raw}
+	result.SetGroupVersionKind(gvk)
+	return result, nil
+}

--- a/pkg/tracecheck/schema_writes_test.go
+++ b/pkg/tracecheck/schema_writes_test.go
@@ -1,0 +1,261 @@
+package tracecheck
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tgoodwin/kamera/pkg/apiserver"
+	"github.com/tgoodwin/kamera/pkg/event"
+	"github.com/tgoodwin/kamera/pkg/replay"
+	"github.com/tgoodwin/kamera/pkg/snapshot"
+	"github.com/tgoodwin/kamera/pkg/tag"
+	"github.com/tgoodwin/kamera/pkg/util"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var schemaWriteTestGVK = schema.GroupVersionKind{Group: "testing.kamera.io", Version: "v1", Kind: "Widget"}
+
+func schemaWriteTestRegistry(t *testing.T) *apiserver.Registry {
+	t.Helper()
+	registry := apiserver.NewRegistry()
+	require.NoError(t, registry.RegisterResourceSchema(schemaWriteTestGVK, true, true, &apiextensionsv1.JSONSchemaProps{
+		Type: "object",
+		Properties: map[string]apiextensionsv1.JSONSchemaProps{
+			"spec": {
+				Type: "object",
+				Properties: map[string]apiextensionsv1.JSONSchemaProps{
+					"first":  {Type: "string"},
+					"second": {Type: "string"},
+				},
+			},
+			"status": {
+				Type: "object",
+				Properties: map[string]apiextensionsv1.JSONSchemaProps{
+					"phase": {Type: "string"},
+				},
+			},
+		},
+	}))
+	return registry
+}
+
+func configMapTestRegistry(t *testing.T) *apiserver.Registry {
+	t.Helper()
+	registry := apiserver.NewRegistry()
+	require.NoError(t, registry.RegisterResourceSchema(
+		corev1.SchemeGroupVersion.WithKind("ConfigMap"), true, false,
+		&apiextensionsv1.JSONSchemaProps{
+			Type: "object",
+			Properties: map[string]apiextensionsv1.JSONSchemaProps{
+				"data": {
+					Type: "object",
+					AdditionalProperties: &apiextensionsv1.JSONSchemaPropsOrBool{
+						Allows: true,
+						Schema: &apiextensionsv1.JSONSchemaProps{Type: "string"},
+					},
+				},
+			},
+		},
+	))
+	return registry
+}
+
+func schemaWriteWidget(fields map[string]interface{}) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": schemaWriteTestGVK.GroupVersion().String(),
+		"kind":       schemaWriteTestGVK.Kind,
+		"metadata": map[string]interface{}{
+			"name":      "example",
+			"namespace": "default",
+		},
+	}}
+	for key, value := range fields {
+		obj.Object[key] = value
+	}
+	return obj
+}
+
+func TestManagerMaterializesRegisteredApplySynchronously(t *testing.T) {
+	registry := schemaWriteTestRegistry(t)
+	resourceSchema, found := registry.Lookup(schemaWriteTestGVK)
+	require.True(t, found)
+	live, err := resourceSchema.Create(schemaWriteWidget(map[string]interface{}{
+		"spec": map[string]interface{}{"first": "one"},
+	}), "initial-manager")
+	require.NoError(t, err)
+
+	store := snapshot.NewStore()
+	mgr := &manager{
+		versionStore:   NewVersionStore(store, nil),
+		effects:        make(map[string]reconcileEffects),
+		scheme:         runtime.NewScheme(),
+		effectRKeys:    make(map[string]util.Set[string]),
+		effectIKeys:    make(map[string]util.Set[snapshot.IdentityKey]),
+		effectRVs:      make(map[string]map[string]int64),
+		effectObjects:  make(map[string]map[string]*unstructured.Unstructured),
+		effectNextRV:   make(map[string]int64),
+		schemaRegistry: registry,
+	}
+	hash := mgr.Publish(live)
+	mgr.rvLookup = func(candidate snapshot.VersionHash) int64 {
+		if candidate == hash {
+			return 5
+		}
+		return 0
+	}
+	key := snapshot.NewCompositeKeyWithGroup(
+		schemaWriteTestGVK.Group, schemaWriteTestGVK.Kind, "default", "example", tag.GetSleeveObjectID(live),
+	)
+	ctx := ctxWithFrame("schema-apply")
+	require.NoError(t, mgr.PrepareEffectContext(ctx, ObjectVersions{key: hash}))
+
+	intent := schemaWriteWidget(map[string]interface{}{
+		"spec": map[string]interface{}{"second": "two"},
+	})
+	err = mgr.RecordEffect(ctx, intent, event.APPLY, &replay.PreconditionInfo{FieldManager: "second-manager"}, nil)
+	require.NoError(t, err)
+	require.Equal(t, "one", intent.Object["spec"].(map[string]interface{})["first"])
+	require.Equal(t, "two", intent.Object["spec"].(map[string]interface{})["second"])
+	require.Equal(t, "6", intent.GetResourceVersion())
+
+	changes, err := mgr.GetEffects(ctx)
+	require.NoError(t, err)
+	require.Len(t, changes.Effects, 1)
+	require.True(t, changes.Effects[0].Materialized)
+	materialized := mgr.Resolve(changes.Effects[0].Version)
+	require.Equal(t, "one", materialized.Object["spec"].(map[string]interface{})["first"])
+	require.Equal(t, "two", materialized.Object["spec"].(map[string]interface{})["second"])
+	require.Equal(t, "6", materialized.GetResourceVersion())
+}
+
+func TestManagerTreatsRepeatedApplyAcrossFramesAsNoOp(t *testing.T) {
+	registry := configMapTestRegistry(t)
+	mgr := newTestManager(nil)
+	mgr.schemaRegistry = registry
+	firstCtx := ctxWithFrame("config-create")
+	require.NoError(t, mgr.PrepareEffectContext(firstCtx, ObjectVersions{}))
+	first := makeObj("example", "")
+	first.Object["data"] = map[string]interface{}{"key": "value"}
+	require.NoError(t, mgr.RecordEffect(firstCtx, first, event.APPLY, &replay.PreconditionInfo{FieldManager: "manager"}, nil))
+	firstChanges, err := mgr.GetEffects(firstCtx)
+	require.NoError(t, err)
+	require.Len(t, firstChanges.Effects, 1)
+	firstEffect := firstChanges.Effects[0]
+	mgr.CleanupEffectContext(firstCtx)
+
+	mgr.rvLookup = func(candidate snapshot.VersionHash) int64 {
+		if candidate == firstEffect.Version {
+			return 1
+		}
+		return 0
+	}
+	key := snapshot.NewCompositeKeyWithGroup("", "ConfigMap", "default", "example", tag.GetSleeveObjectID(first))
+	secondCtx := ctxWithFrame("config-no-op")
+	require.NoError(t, mgr.PrepareEffectContext(secondCtx, ObjectVersions{key: firstEffect.Version}))
+	second := makeObj("example", "")
+	second.Object["data"] = map[string]interface{}{"key": "value"}
+	require.NoError(t, mgr.RecordEffect(secondCtx, second, event.APPLY, &replay.PreconditionInfo{FieldManager: "manager"}, nil))
+	secondChanges, err := mgr.GetEffects(secondCtx)
+	require.NoError(t, err)
+	require.Len(t, secondChanges.Effects, 1)
+	require.Equal(t, firstEffect.Version, secondChanges.Effects[0].Version)
+	require.Equal(t, int64(1), second.GetGeneration())
+}
+
+func TestManagerStrictModeRejectsUnregisteredWrites(t *testing.T) {
+	mgr := newTestManager(nil)
+	mgr.schemaRegistry = apiserver.NewRegistry()
+	mgr.requireSchemas = true
+	ctx := ctxWithFrame("strict-schema")
+	require.NoError(t, mgr.PrepareEffectContext(ctx, ObjectVersions{}))
+
+	err := mgr.RecordEffect(ctx, makeObj("example", ""), event.APPLY, &replay.PreconditionInfo{FieldManager: "manager"}, nil)
+	require.ErrorContains(t, err, "schema-backed APPLY by reconciler \"unknown\" requires a registered schema for /v1, Kind=ConfigMap")
+}
+
+func TestManagerRejectsForcedApplyWithSecondControllerOwner(t *testing.T) {
+	registry := schemaWriteTestRegistry(t)
+	resourceSchema, found := registry.Lookup(schemaWriteTestGVK)
+	require.True(t, found)
+	controller := true
+	ownerA := metav1.OwnerReference{
+		APIVersion: "testing.kamera.io/v1", Kind: "Owner", Name: "a", UID: types.UID("owner-a"), Controller: &controller,
+	}
+	ownerB := metav1.OwnerReference{
+		APIVersion: "testing.kamera.io/v1", Kind: "Owner", Name: "b", UID: types.UID("owner-b"), Controller: &controller,
+	}
+	initial := schemaWriteWidget(nil)
+	initial.SetOwnerReferences([]metav1.OwnerReference{ownerA})
+	live, err := resourceSchema.Create(initial, "owner-a-manager")
+	require.NoError(t, err)
+
+	mgr := newTestManager(nil)
+	mgr.schemaRegistry = registry
+	hash := mgr.Publish(live)
+	key := snapshot.NewCompositeKeyWithGroup(
+		schemaWriteTestGVK.Group, schemaWriteTestGVK.Kind, "default", "example", tag.GetSleeveObjectID(live),
+	)
+	ctx := ctxWithFrame("invalid-owner-apply")
+	require.NoError(t, mgr.PrepareEffectContext(ctx, ObjectVersions{key: hash}))
+	second := schemaWriteWidget(nil)
+	second.SetOwnerReferences([]metav1.OwnerReference{ownerB})
+
+	err = mgr.RecordEffect(ctx, second, event.APPLY, &replay.PreconditionInfo{
+		FieldManager: "owner-b-manager",
+		Force:        true,
+	}, nil)
+	require.True(t, apierrors.IsInvalid(err), "force must not bypass merged ObjectMeta validation: %v", err)
+	changes, getErr := mgr.GetEffects(ctx)
+	require.NoError(t, getErr)
+	require.Empty(t, changes.Effects, "invalid write must not record a durable effect")
+}
+
+func TestBuildStartStateSeedsOwnershipAndStrictlyRequiresSchemas(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	builder := NewExplorerBuilder(scheme).RequireSchemas()
+	obj := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "example", Namespace: "default"}}
+
+	_, err := builder.BuildStartStateFromObjects([]client.Object{obj}, nil)
+	require.ErrorContains(t, err, "requires a registered schema for /v1, Kind=ConfigMap")
+}
+
+func TestBuildStartStateSeedsOwnershipAndForkRetainsSchemas(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	builder := NewExplorerBuilder(scheme).
+		RequireSchemas().
+		WithResourceSchema(corev1.SchemeGroupVersion.WithKind("ConfigMap"), true, false,
+			&apiextensionsv1.JSONSchemaProps{Type: "object", Properties: map[string]apiextensionsv1.JSONSchemaProps{
+				"data": {Type: "object", AdditionalProperties: &apiextensionsv1.JSONSchemaPropsOrBool{
+					Allows: true, Schema: &apiextensionsv1.JSONSchemaProps{Type: "string"},
+				}},
+			}})
+	fork := builder.Fork()
+	obj := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "example", Namespace: "default"},
+		Data:       map[string]string{"key": "value"},
+	}
+
+	state, err := fork.BuildStartStateFromObjects([]client.Object{obj}, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, obj.GetManagedFields())
+	require.Equal(t, initialFieldManager, obj.GetManagedFields()[0].Manager)
+	require.Len(t, state.Objects(), 1)
+
+	stateBuilderObj := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "event-builder", Namespace: "default"},
+		Data:       map[string]string{"key": "value"},
+	}
+	stateBuilderState := builder.NewStateEventBuilder().AddTopLevelObject(stateBuilderObj)
+	require.NotEmpty(t, stateBuilderObj.GetManagedFields())
+	require.Len(t, stateBuilderState.Objects(), 1)
+}

--- a/pkg/tracecheck/statebuilder.go
+++ b/pkg/tracecheck/statebuilder.go
@@ -19,12 +19,13 @@ import (
 
 // StateEventBuilder helps create a sequence of state events
 type StateEventBuilder struct {
-	store        *snapshot.Store
-	events       []StateEvent
-	sequence     int64
-	currentTime  time.Time
-	scheme       *runtime.Scheme
-	reconcileIDs map[string]int
+	store          *snapshot.Store
+	events         []StateEvent
+	sequence       int64
+	currentTime    time.Time
+	scheme         *runtime.Scheme
+	reconcileIDs   map[string]int
+	prepareInitial func(client.Object) error
 }
 
 func NewStateEventBuilder(store *snapshot.Store, scheme *runtime.Scheme) *StateEventBuilder {
@@ -140,6 +141,11 @@ func ensureObjectGVK(obj client.Object, scheme *runtime.Scheme) schema.GroupVers
 }
 
 func (b *StateEventBuilder) AddTopLevelObject(obj client.Object, dependentControllers ...ReconcilerID) StateNode {
+	if b.prepareInitial != nil {
+		if err := b.prepareInitial(obj); err != nil {
+			panic("preparing top-level object: " + err.Error())
+		}
+	}
 	tag.EnsureDeterministicIdentity(obj)
 	gvk := ensureObjectGVK(obj, b.scheme)
 


### PR DESCRIPTION
## Summary

- add explicit CRD, structural-resource, and OpenAPI v3 schema registration to `ExplorerBuilder`, plus opt-in fail-closed `RequireSchemas()`
- preserve complete raw/typed apply requests and their field manager, force, dry-run, validation, patch-type, subresource, and reconciler metadata
- materialize registered CREATE, UPDATE, APPLY, and status APPLY calls synchronously with Kubernetes' upstream managed-fields engine
- persist branch-local `metadata.managedFields`, seed deterministic fixture ownership, and make `applyEffects` a commit layer for materialized results
- validate merged ObjectMeta synchronously, including the two-`controller=true` owner-reference case behind #78
- register ConfigMap schema in the Crossplane harness and document the exact first-milestone boundary

## Why

Kamera previously committed partial apply intent as a full-object replacement. That erased fields owned by other controllers and could not reproduce Kubernetes' schema-aware list-map merging or post-merge validation.

The C4 case needs owner references to merge by UID even with force ownership, followed by generic metadata validation rejecting the resulting two controller owners. Running this at the recorder boundary returns `Invalid` to the controller before an effect is recorded.

## Exact in this milestone

For registered, single-version resources:

- schema-aware SSA topology and managed ownership
- conflicts, force transfer, shared ownership, and omission
- CREATE and UPDATE ownership
- main and status APPLY isolation
- generic ObjectMeta and owner-reference validation
- synchronous frame-local writes and true no-op suppression
- deterministic initial ownership and managed-field timestamps

## Deliberate limitations

- unregistered resources retain legacy behavior unless `RequireSchemas()` is enabled
- non-apply JSON, merge, and strategic patch materialization/ownership remains follow-up work
- dynamic CRD lifecycle, multi-version conversion, structural defaulting/pruning/validation, CEL, admission, scale, and complete built-in handwritten validation are not included
- incremental runs that interleave registered and legacy writes can still approximate returned resource-version ordering

These boundaries are documented in `docs/design/schema-backed-write-engine.md` and tracked as follow-up yaks.

## Verification

- `GOCACHE=/private/tmp/kamera-gocache go test ./...`
- `cd examples/crossplane && GOCACHE=/private/tmp/kamera-gocache go test ./...`
- focused coverage for raw YAML apply, typed apply configurations, list-map/set/atomic topology, conflicts/force/omission/shared ownership, status isolation, strict schema errors, initial ownership, cross-frame no-ops, and invalid forced controller-owner merges

Campaign note: the representative Crossplane steady-state workflow has a pre-existing repeated Composite reconcile loop and produces no truly converged terminal dump. The clean baseline reached 51 unique nodes / 13 resource states; the final run reached 68 / 18 because managed-field ownership is now logical state. No max-depth result is presented as convergence evidence.

Closes #78.
Implements the first milestone of #82.